### PR TITLE
Mac: fix up the actual executable name for inspector

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/Build.targets
+++ b/Clients/Xamarin.Interactive.Client.Mac/Build.targets
@@ -47,6 +47,19 @@
     <Exec Command="rm -rf &quot;$(InspectorAppBundle)&quot;" />
     <Exec Command="cp -a @(WorkbookClientAppBundle-&gt;'&quot;%(Identity)&quot;', ' ') &quot;$(InspectorAppBundle)&quot;" />
     <Exec Command="cp -a &quot;Resources\AppIconInspector.icns&quot; &quot;$(InspectorAppBundle)Contents\Resources\AppIcon.icns&quot;" />
+    <Move
+      SourceFiles="$(InspectorAppBundle)\Contents\MonoBundle\Xamarin Workbooks.exe"
+      DestinationFiles="$(InspectorAppBundle)\Contents\MonoBundle\Xamarin Inspector.exe"/>
+    <Move
+      Condition="Exists('$(InspectorAppBundle)\Contents\MonoBundle\Xamarin Workbooks.pdb')"
+      SourceFiles="$(InspectorAppBundle)\Contents\MonoBundle\Xamarin Workbooks.pdb"
+      DestinationFiles="$(InspectorAppBundle)\Contents\MonoBundle\Xamarin Inspector.pdb"/>
+    <Move
+      SourceFiles="$(InspectorAppBundle)\Contents\MacOS\Xamarin Workbooks"
+      DestinationFiles="$(InspectorAppBundle)\Contents\MacOS\Xamarin Inspector"/>
+    <RemoveDir Directories="$(InspectorAppBundle)\Contents\Resources\Workbooks"/>
+    <RemoveDir Directories="$(InspectorAppBundle)\Contents\MacOS\Xamarin Workbooks.dSYM"/>
+
     <!--
       Create the final Workbooks Info.plist by merging in Workbooks-specific
       pieces from Workbooks.plist. We delete a bunch of entries first in order
@@ -82,6 +95,14 @@
       Plist="$(InspectorAppInfoPlist)"
       Selector="CFBundleName"
       NewValue="Xamarin Inspector" />
+    <SetPlistValue
+      Plist="$(InspectorAppInfoPlist)"
+      Selector="CFBundleExecutable"
+      NewValue="Xamarin Inspector" />
+    <SetPlistValue
+      Plist="$(InspectorAppInfoPlist)"
+      Selector="MonoBundleExecutable"
+      NewValue="Xamarin Inspector.exe" />
     <!-- Finally, re-convert these to binary. -->
     <Exec Command="plutil -convert binary1 &quot;$(WorkbookAppInfoPlist)&quot;" />
     <Exec Command="plutil -convert binary1 &quot;$(InspectorAppInfoPlist)&quot;" />

--- a/Clients/Xamarin.Interactive.Client/Client/ClientInfo.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ClientInfo.cs
@@ -6,6 +6,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 
@@ -25,10 +26,7 @@ namespace Xamarin.Interactive.Client
         public static ClientFlavor Flavor {
             get {
                 if (flavor == null) {
-                    if (Assembly
-                        .GetEntryAssembly ()
-                        .GetName ()
-                        .Name
+                    if (Path.GetFileName (Process.GetCurrentProcess ().MainModule.FileName)
                         .IndexOf ("workbook", StringComparison.OrdinalIgnoreCase) >= 0)
                         flavor = ClientFlavor.Workbooks;
                     else


### PR DESCRIPTION
Use the process executable instead of the entry assembly to infer whether workbooks or inspector is running.

I had toyed with using cecil to change the assembly name (not just rename it), but doing so breaks registration in the XM runtime, and there is not a clean way to redirect it. We would have to re-mmp
the whole app, which is very slow.
