### PR TITLE
Xamarin.Interactive.Client: appease VS Mac

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Build.windows.targets
+++ b/Clients/Xamarin.Interactive.Client/Build.windows.targets
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CrossBrowser\Xamarin.CrossBrowser.Wpf\Xamarin.CrossBrowser.Wpf.csproj" />
+  </ItemGroup>
+</Project>

--- a/Clients/Xamarin.Interactive.Client/Xamarin.Interactive.Client.csproj
+++ b/Clients/Xamarin.Interactive.Client/Xamarin.Interactive.Client.csproj
@@ -18,7 +18,6 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Condition="'$(OS)' == 'Windows_NT'" Include="PresentationCore" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.3.0" />
@@ -29,7 +28,6 @@
     <ProjectReference Include="..\..\Agents\Xamarin.Interactive\Xamarin.Interactive.csproj" />
     <ProjectReference Include="..\..\External\CommonMark.NET\CommonMark\CommonMark.Base.csproj" />
     <ProjectReference Include="..\..\External\Xamarin.PropertyEditing\Xamarin.PropertyEditing\Xamarin.PropertyEditing.csproj" />
-    <ProjectReference Condition="'$(OS)' == 'Windows_NT'" Include="..\CrossBrowser\Xamarin.CrossBrowser.Wpf\Xamarin.CrossBrowser.Wpf.csproj" />
     <ProjectReference Condition="'$(OS)' == 'Unix'" Include="..\System.Windows.Input\System.Windows.Input.csproj" />
     <ProjectReference Condition="'$(OS)' == 'Unix'" Include="..\CrossBrowser\Xamarin.CrossBrowser.Mac\Xamarin.CrossBrowser.Mac.csproj" />
   </ItemGroup>
@@ -42,6 +40,7 @@
     <Folder Include="SystemInformation\" />
     <Folder Include="Markdown\" />
   </ItemGroup>
+  <Import Condition="'$(OS)' == 'Windows_NT'" Project="Build.windows.targets"/>
   <Import Project="..\..\Bootstrap\Xamarin.Interactive.Bootstrap\Xamarin.Interactive.Bootstrap.projitems" Label="Shared" Condition="Exists('..\..\Bootstrap\Xamarin.Interactive.Bootstrap\Xamarin.Interactive.Bootstrap.projitems')" />
   <Import Project="..\..\Agents\Xamarin.Interactive\Xamarin.Interactive.Shared.projitems" Label="Shared" Condition="Exists('..\..\Agents\Xamarin.Interactive\Xamarin.Interactive.Shared.projitems')" />
   <Import Project="..\..\Build\Common.targets" />


### PR DESCRIPTION
The VS Mac project model is still not fully backed by MSBuild. As such, it (a) ignores Conditions on `Reference`/`ProjectReference` items, and (b) does not pick up on any `Reference`/`ProjectReference` in imported targets files.

So the trick is to make the csproj look Mac-only, with proper conditions that are ignored in the IDE (but respected in actual MSBuild) and import windows-specific targets that both VS and MSBuild will respect on Windows.
