### PR TITLE
Client: Preference for word wrapping in editor.

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/Main.storyboard
+++ b/Clients/Xamarin.Interactive.Client.Mac/Main.storyboard
@@ -232,11 +232,11 @@ Gw
             <objects>
                 <viewController id="5cL-NK-hn5" customClass="PreferencesGeneralViewController" sceneMemberID="viewController">
                     <view key="view" id="mYQ-Sa-Mcy" customClass="PreferencesView">
-                        <rect key="frame" x="0.0" y="0.0" width="285" height="189"/>
+                        <rect key="frame" x="0.0" y="0.0" width="285" height="204"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="o2R-eF-eWs">
-                                <rect key="frame" x="18" y="149" width="64" height="17"/>
+                                <rect key="frame" x="18" y="164" width="64" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Font Size:" id="C5l-d8-3KG">
                                     <font key="font" metaFont="system"/>
@@ -245,7 +245,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GY4-9b-LLW">
-                                <rect key="frame" x="119" y="144" width="19" height="27"/>
+                                <rect key="frame" x="119" y="159" width="19" height="27"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <stepperCell key="cell" continuous="YES" alignment="left" minValue="1" maxValue="1" doubleValue="1" id="Ue1-oi-xnt"/>
                                 <connections>
@@ -253,7 +253,7 @@ Gw
                                 </connections>
                             </stepper>
                             <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="72g-Vx-pTW">
-                                <rect key="frame" x="88" y="146" width="32" height="22"/>
+                                <rect key="frame" x="88" y="161" width="32" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="uqa-rh-SCR">
                                     <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="Pek-zN-6C0">
@@ -268,16 +268,16 @@ Gw
                                     <binding destination="5cL-NK-hn5" name="value" keyPath="self.fontSize" id="CcG-AB-Re3"/>
                                 </connections>
                             </textField>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CsM-Hg-B4E">
-                                <rect key="frame" x="18" y="71" width="132" height="18"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pTJ-Gx-mtX">
+                                <rect key="frame" x="18" y="87" width="169" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="check" title="Save REPL history" bezelStyle="regularSquare" imagePosition="left" inset="2" id="SdN-lq-CqP">
+                                <buttonCell key="cell" type="check" title="Wrap long lines in code cell editors" bezelStyle="regularSquare" imagePosition="left" inset="2" id="5zo-g7-82A">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="je4-5N-EDQ">
-                                <rect key="frame" x="18" y="97" width="249" height="18"/>
+                                <rect key="frame" x="18" y="112" width="249" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Show execution timings on code cells" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ziB-Yc-Gq0">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -285,7 +285,7 @@ Gw
                                 </buttonCell>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WGo-hM-s2P">
-                                <rect key="frame" x="18" y="122" width="216" height="18"/>
+                                <rect key="frame" x="18" y="137" width="216" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Show line numbers in code cells" bezelStyle="regularSquare" imagePosition="left" inset="2" id="NgJ-Wd-E6z">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -303,6 +303,14 @@ Gw
                                     <action selector="ResetAllPreferences:" target="5cL-NK-hn5" id="WHX-J7-xxC"/>
                                 </connections>
                             </button>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CsM-Hg-B4E">
+                                <rect key="frame" x="18" y="62" width="132" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Save REPL history" bezelStyle="regularSquare" imagePosition="left" inset="2" id="SdN-lq-CqP">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
                         </subviews>
                     </view>
                     <connections>
@@ -311,12 +319,13 @@ Gw
                         <outlet property="saveHistoryCheckButton" destination="CsM-Hg-B4E" id="O0n-8m-quh"/>
                         <outlet property="showExecutionTimingsCheckButton" destination="je4-5N-EDQ" id="c6U-gp-1gx"/>
                         <outlet property="showLineNumbersCheckButton" destination="WGo-hM-s2P" id="I3l-P9-Fys"/>
+                        <outlet property="wrapLongLinesInEditorCheckButton" destination="pTJ-Gx-mtX" id="L3q-c1-stF"/>
                     </connections>
                 </viewController>
                 <customObject id="rmc-9D-tj4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <userDefaultsController representsSharedInstance="YES" id="Aoc-p7-NIA"/>
             </objects>
-            <point key="canvasLocation" x="-1358" y="1799"/>
+            <point key="canvasLocation" x="-1358.5" y="1806"/>
         </scene>
         <!--Preferences Feedback View Controller-->
         <scene sceneID="NCH-6O-JYw">

--- a/Clients/Xamarin.Interactive.Client.Mac/Preferences/PreferencesGeneralViewController.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/Preferences/PreferencesGeneralViewController.cs
@@ -54,6 +54,10 @@ namespace Xamarin.Interactive.Preferences
             AddCheckButtonPreference (
                 Prefs.Repl.SaveHistory,
                 saveHistoryCheckButton);
+
+            AddCheckButtonPreference (
+                Prefs.Submissions.WrapLongLinesInEditor,
+                wrapLongLinesInEditorCheckButton);
         }
 
         protected override void ObservePreferenceChange (PreferenceChange change)

--- a/Clients/Xamarin.Interactive.Client.Mac/Preferences/PreferencesGeneralViewController.designer.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/Preferences/PreferencesGeneralViewController.designer.cs
@@ -1,6 +1,6 @@
 // WARNING
 //
-// This file has been generated automatically by Xamarin Studio to store outlets and
+// This file has been generated automatically by Visual Studio to store outlets and
 // actions made in the UI designer. If it is removed, they will be lost.
 // Manual changes to this file may not be handled correctly.
 //
@@ -27,9 +27,12 @@ namespace Xamarin.Interactive.Preferences
         [Outlet]
         AppKit.NSButton showLineNumbersCheckButton { get; set; }
 
+        [Outlet]
+        AppKit.NSButton wrapLongLinesInEditorCheckButton { get; set; }
+
         [Action ("ResetAllPreferences:")]
         partial void ResetAllPreferences (Foundation.NSObject sender);
-        
+
         void ReleaseDesignerOutlets ()
         {
             if (fontSizeStepper != null) {
@@ -55,6 +58,11 @@ namespace Xamarin.Interactive.Preferences
             if (showLineNumbersCheckButton != null) {
                 showLineNumbersCheckButton.Dispose ();
                 showLineNumbersCheckButton = null;
+            }
+
+            if (wrapLongLinesInEditorCheckButton != null) {
+                wrapLongLinesInEditorCheckButton.Dispose ();
+                wrapLongLinesInEditorCheckButton = null;
             }
         }
     }

--- a/Clients/Xamarin.Interactive.Client.Windows/Views/OptionsWindow.xaml
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/OptionsWindow.xaml
@@ -71,6 +71,11 @@
                             IsChecked="{Binding ShowSubmissionExecutionTimings, Mode=TwoWay}">
                             <TextBlock Text="Show execution timings on code cells" />
                         </CheckBox>
+                        <CheckBox
+                            Margin="0,10,0,0"
+                            IsChecked="{Binding WrapLongLinesInEditor, Mode=TwoWay}">
+                            <TextBlock Text="Wrap long lines in code cell editors" />
+                        </CheckBox>
                     </StackPanel>
                 </GroupBox>
                 <GroupBox

--- a/Clients/Xamarin.Interactive.Client.Windows/Views/OptionsWindow.xaml.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/OptionsWindow.xaml.cs
@@ -56,6 +56,14 @@ namespace Xamarin.Interactive.Client.Windows.Views
             }
         }
 
+        public bool WrapLongLinesInEditor {
+            get { return Prefs.Submissions.WrapLongLinesInEditor.GetValue (); }
+            set {
+                Prefs.Submissions.WrapLongLinesInEditor.SetValue (value);
+                OnPropertyChanged ();
+            }
+        }
+
         public bool SaveHistory {
             get { return Prefs.Repl.SaveHistory.GetValue (); }
             set {
@@ -162,6 +170,8 @@ namespace Xamarin.Interactive.Client.Windows.Views
                 OnPropertyChanged (nameof (UpdateChannel));
             else if (change.Key == Prefs.UI.Theme.ThemeName.Key)
                 OnPropertyChanged (nameof (CurrentTheme));
+            else if (change.Key == Prefs.Submissions.WrapLongLinesInEditor.Key)
+                OnPropertyChanged (nameof (WrapLongLinesInEditor));
         }
 
         void OnResetAllPreferences (object sender, RoutedEventArgs e)

--- a/Clients/Xamarin.Interactive.Client/ClientApp/editor/editor.css
+++ b/Clients/Xamarin.Interactive.Client/ClientApp/editor/editor.css
@@ -66,7 +66,7 @@ Copyright 2016 Microsoft. All rights reserved.
 
 .monaco-editor .editor-widget,
 .monaco-editor .monaco-editor-hover {
-	z-index: 10000; /* Same as our UI dropdowns */
+  z-index: 10000; /* Same as our UI dropdowns */
 }
 
 .monaco-editor .current-line {

--- a/Clients/Xamarin.Interactive.Client/ClientApp/workbook/code-editor.ts
+++ b/Clients/Xamarin.Interactive.Client/ClientApp/workbook/code-editor.ts
@@ -136,8 +136,7 @@ interface WorkbookCodeEditorOptions {
   onFocus?: () => void
   onChange?: (event: WorkbookCodeEditorChangeEvent) => void
   theme?: string,
-  wordWrap?: "off" | "on" | "wordWrapColumn" | "bounded",
-  scrollbarHorizontal?: "auto" | "hidden"
+  wrapLongLines: boolean,
 }
 
 class WorkbookCodeEditor {
@@ -159,7 +158,7 @@ class WorkbookCodeEditor {
       fontSize: options.fontSize,
       overviewRulerLanes: 0, // 0 = hide overview ruler
       formatOnType: true,
-      wordWrap: options.wordWrap || 'on',
+      wordWrap: options.wrapLongLines ? "on" : "off",
       renderIndentGuides: false,
       contextmenu: false,
       cursorBlinking: 'phase',
@@ -168,7 +167,7 @@ class WorkbookCodeEditor {
       },
       scrollbar: {
         // must explicitly hide scrollbars so they don't interfere with mouse events
-        horizontal: options.scrollbarHorizontal || 'hidden',
+        horizontal: options.wrapLongLines ? "hidden" : "auto",
         vertical: 'hidden',
         handleMouseWheel: false,
         useShadows: false,
@@ -180,7 +179,7 @@ class WorkbookCodeEditor {
     this.mEditor = monaco.editor.create(
       options.placeElem, this.monacoEditorOptions)
 
-    monaco.editor.setTheme(options.theme)
+    monaco.editor.setTheme(options.theme || "vs")
     this.mEditor.onKeyDown(e => this.onKeyDown(e))
 
     if (this.options.onChange)
@@ -317,6 +316,12 @@ class WorkbookCodeEditor {
 
   setTheme(themeName: string) {
     monaco.editor.setTheme(themeName)
+  }
+
+  setWordWrap(wrapLongLines: boolean) {
+    this.monacoEditorOptions.wordWrap = wrapLongLines ? "on" : "off"
+    this.monacoEditorOptions.scrollbar.horizontal = wrapLongLines ? "hidden" : "auto"
+    this.updateOptions()
   }
 
   setShowLineNumbers(showLineNumbers: boolean) {

--- a/Clients/Xamarin.Interactive.Client/Preferences/Prefs.cs
+++ b/Clients/Xamarin.Interactive.Client/Preferences/Prefs.cs
@@ -51,6 +51,9 @@ namespace Xamarin.Interactive.Preferences
 
             public static readonly Preference<bool> ShowExecutionTimings
                 = new Preference<bool> ("submissions.showExecutionTimings", false);
+
+            public static readonly Preference<bool> WrapLongLinesInEditor
+                = new Preference<bool> ("submissions.wrapLongLinesInEditor", true);
         }
 
         public static class Repl

--- a/Clients/Xamarin.Interactive.Client/Workbook/Views/CodeCellEditorView.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Views/CodeCellEditorView.cs
@@ -76,6 +76,7 @@ namespace Xamarin.Interactive.Workbook.Views
                 o.onCursorUpDown = (ScriptFunc)HandleCursorUpDown;
                 o.onEnter = (ScriptFunc)HandleEnter;
                 o.theme = GetThemeName ();
+                o.wrapLongLines = Prefs.Submissions.WrapLongLinesInEditor.GetValue ();
             }));
 
             codeCell.CodeAnalysisBuffer.TextChanged += HandleBufferTextChanged;
@@ -90,6 +91,8 @@ namespace Xamarin.Interactive.Workbook.Views
                     codeEditor.setShowLineNumbers (Prefs.Editor.ShowLineNumbers.GetValue ());
                 else if (change.Key == Prefs.UI.Theme.UseHighContrast.Key || change.Key == Prefs.UI.Theme.ThemeName.Key)
                     codeEditor.setTheme (GetThemeName ());
+                else if (change.Key == Prefs.Submissions.WrapLongLinesInEditor.Key)
+                    codeEditor.setWordWrap (Prefs.Submissions.WrapLongLinesInEditor.GetValue ());
             });
         }
 

--- a/UPDATES.md
+++ b/UPDATES.md
@@ -7,6 +7,9 @@ product documentation for [Workbooks][docs-workbooks] and
 
 ## NEW & IMPROVED
 
+* Users can now choose whether long lines in the code editor should be
+  wrapped or not via a preference.
+
 ## FIXED
 
 * Additional accessibility fixes for High Contrast mode users, particularly


### PR DESCRIPTION
Add a preference to allow turning off word wrap. Defaults to true to match existing behavior.
When enabled, scrollbars appear only when the too-wide cell is in focus.

### Screenshots

<details>
<summary>Expand to view screenshots</summary>

![image](https://user-images.githubusercontent.com/110747/32392910-e35cc21e-c0ad-11e7-8a5f-a612bda088be.png)
![image](https://user-images.githubusercontent.com/110747/32393017-56aee10c-c0ae-11e7-83a9-864c6e2e694d.png)
![image](https://user-images.githubusercontent.com/110747/32393046-73b10640-c0ae-11e7-940b-f4e887eaf304.png)

</details>

### Merge Readiness
- [X] Does this warrant an UPDATES.md entry?
