### PR TITLE
Add return types to the hover provider display

### DIFF
--- a/Clients/Xamarin.Interactive.Client/CodeAnalysis/Monaco/HoverProvider.cs
+++ b/Clients/Xamarin.Interactive.Client/CodeAnalysis/Monaco/HoverProvider.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Interactive.CodeAnalysis.Monaco
             if (symbolInfo.Symbol == null)
                 return hover;
 
-            hover.Contents = new [] { symbolInfo.Symbol.ToDisplayString (SymbolDisplayFormat.MinimallyQualifiedFormat) };
+            hover.Contents = new [] { symbolInfo.Symbol.ToMonacoSignatureString () };
             hover.Range = syntaxToken.GetLocation ().GetLineSpan ().Span;
 
             return hover;

--- a/Clients/Xamarin.Interactive.Client/CodeAnalysis/Monaco/MonacoExtensions.cs
+++ b/Clients/Xamarin.Interactive.Client/CodeAnalysis/Monaco/MonacoExtensions.cs
@@ -23,12 +23,18 @@ namespace Xamarin.Interactive.CodeAnalysis.Monaco
     {
         const string TAG = nameof (MonacoExtensions);
 
-        static readonly SymbolDisplayFormat parameterSymbolDisplayFormat = SymbolDisplayFormat.CSharpErrorMessageFormat
+        static readonly SymbolDisplayFormat symbolDisplayFormat = SymbolDisplayFormat.CSharpErrorMessageFormat
             .WithParameterOptions (
                 SymbolDisplayParameterOptions.IncludeName |
                 SymbolDisplayParameterOptions.IncludeType |
                 SymbolDisplayParameterOptions.IncludeDefaultValue |
-                SymbolDisplayParameterOptions.IncludeParamsRefOut);
+                SymbolDisplayParameterOptions.IncludeParamsRefOut)
+            .WithMemberOptions (
+                SymbolDisplayMemberOptions.IncludeParameters |
+                SymbolDisplayMemberOptions.IncludeContainingType |
+                SymbolDisplayMemberOptions.IncludeType |
+                SymbolDisplayMemberOptions.IncludeRef |
+                SymbolDisplayMemberOptions.IncludeExplicitInterface);
 
         public static CancellationToken FromMonacoCancellationToken (dynamic token)
         {
@@ -96,36 +102,8 @@ namespace Xamarin.Interactive.CodeAnalysis.Monaco
         public static LinePosition FromMonacoPosition (dynamic position) =>
             new LinePosition ((int)position.lineNumber - 1, (int)position.column - 1);
 
-        static readonly ThreadLocal<StringBuilder> localSignatureBuilder =
-            new ThreadLocal<StringBuilder> (() => new StringBuilder (256));
-        public static string ToMonacoSignatureString (this IMethodSymbol method)
-        {
-            var signatureBuilder = localSignatureBuilder.Value;
-            signatureBuilder.Length = 0;
-
-            if (method.MethodKind == MethodKind.Constructor)
-                signatureBuilder.Append (method.ContainingType.Name);
-            else
-                signatureBuilder
-                    .Append (method.ReturnType)
-                    .Append (' ')
-                    .Append (method.Name);
-
-            signatureBuilder.Append (" (");
-
-            for (var i = 0; i < method.Parameters.Length; i++) {
-                if (i > 0)
-                    signatureBuilder.Append (", ");
-                signatureBuilder.Append (method.Parameters [i].ToMonacoSignatureString ());
-            }
-
-            signatureBuilder.Append (')');
-
-            return signatureBuilder.ToString ();
-        }
-
-        public static string ToMonacoSignatureString (this IParameterSymbol parameter)
-            => parameter.ToDisplayString (parameterSymbolDisplayFormat);
+        public static string ToMonacoSignatureString (this ISymbol symbol) =>
+            symbol.ToDisplayString (symbolDisplayFormat);
 
         public static int ToMonacoCompletionItemKind (ImmutableArray<string> completionTags)
         {


### PR DESCRIPTION
The the parameterless ISymbol.ToDisplayString() doesn't include the return type for the hover provider so we pass SymbolDisplayFormat.MinimallyQualifiedFormat which does.

Before
![image](https://user-images.githubusercontent.com/24063/32462036-96784142-c2fd-11e7-987f-4f14f9627f9b.png)
![image](https://user-images.githubusercontent.com/24063/32462294-83f296d4-c2fe-11e7-8f6d-2c76c57899b3.png)


After

![image](https://user-images.githubusercontent.com/24063/32680729-a8588336-c631-11e7-859f-86e1ae4a91c7.png)
