### PR TITLE
Build: Fix UpdateWixManifest

### DIFF
--- a/Build/Xamarin.Build/MSBuild/UpdateWixManifest.cs
+++ b/Build/Xamarin.Build/MSBuild/UpdateWixManifest.cs
@@ -38,7 +38,7 @@ namespace Xamarin.MSBuild
 
         public string IdPrefix { get; set; } = string.Empty;
         public bool ScanRecursively { get; set; } = false;
-        public string [] IncludedExtensions { get; set; } = new [] { "*.dll" };
+        public string [] IncludedExtensions { get; set; } = new [] { "dll" };
         public string [] ExcludedExtensions { get; set; } = Array.Empty<string> ();
         public bool FailOnManifestChanges { get; set; } = true;
         public bool UseHashForId { get; set; } = false;


### PR DESCRIPTION
Extraneous `*.` caused assemblies without an extra `.` to be missed by
default, including `netstandard.dll` in https://github.com/Microsoft/workbooks/pull/3.