### PR TITLE
Telemetry: queue events until client is available

### DIFF
--- a/Clients/Xamarin.Interactive.Client/ClientApp.cs
+++ b/Clients/Xamarin.Interactive.Client/ClientApp.cs
@@ -82,6 +82,8 @@ namespace Xamarin.Interactive
             bool asSharedInstance = true,
             ILogProvider logProvider = null)
         {
+            new Telemetry.Events.AppSessionInitialize ().Post ();
+
             Log.Initialize (logProvider ?? new LogProvider (
                 #if DEBUG
                 LogLevel.Debug
@@ -195,7 +197,7 @@ namespace Xamarin.Interactive
             logStream.Write (bytes, 0, bytes.Length);
             logStream.Flush ();
 
-            if (entry.Flags.HasFlag (LogFlags.SkipTelemetry) || SharedInstance?.Telemetry == null)
+            if (entry.Flags.HasFlag (LogFlags.SkipTelemetry))
                 return;
 
             switch (entry.Level) {

--- a/Clients/Xamarin.Interactive.Client/Telemetry/EventExtensions.cs
+++ b/Clients/Xamarin.Interactive.Client/Telemetry/EventExtensions.cs
@@ -5,12 +5,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
+
 namespace Xamarin.Interactive
 {
     static class TelemetryEventExtensions
     {
+        static readonly BlockingCollection<Telemetry.IDataEvent> pendingEvents
+            = new BlockingCollection<Telemetry.IDataEvent> ();
+
         public static void Post (this Telemetry.IDataEvent evnt, Telemetry.Client client = null)
-            => (client ?? ClientApp.SharedInstance.Telemetry).Post (evnt);
+        {
+            if (client != null) {
+                client.Post (evnt);
+                return;
+            }
+
+            client = ClientApp.SharedInstance?.Telemetry;
+
+            if (client == null) {
+                pendingEvents.Add (evnt);
+                return;
+            }
+
+            pendingEvents.CompleteAdding ();
+
+            while (pendingEvents.TryTake (out var pendingEvent))
+                client.Post (pendingEvent);
+
+            client.Post (evnt);
+        }
 
         public static void Post (this Telemetry.IEvent evnt, Telemetry.Client client = null)
             => Post (new Telemetry.Event (evnt.Key, evnt.Timestamp), client);

--- a/Clients/Xamarin.Interactive.Client/Telemetry/Events/AppSessionInitialize.cs
+++ b/Clients/Xamarin.Interactive.Client/Telemetry/Events/AppSessionInitialize.cs
@@ -1,0 +1,16 @@
+﻿//
+// Author:
+//   Aaron Bockover <abock@xamarin.com>
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Xamarin.Interactive.Telemetry.Events
+{
+    sealed class AppSessionInitialize : Event
+    {
+        public AppSessionInitialize () : base ("app.sessionInit")
+        {
+        }
+    }
+}

--- a/Clients/Xamarin.Interactive.Client/Telemetry/Events/AppSessionStart.cs
+++ b/Clients/Xamarin.Interactive.Client/Telemetry/Events/AppSessionStart.cs
@@ -12,7 +12,6 @@ using Newtonsoft.Json;
 
 using Xamarin.Interactive.Logging;
 using Xamarin.Interactive.Preferences;
-using Xamarin.Interactive.SystemInformation;
 
 namespace Xamarin.Interactive.Telemetry.Events
 {


### PR DESCRIPTION
Add an `app.sessionInit` event to post as soon as `ClientApp.Initialize` is called. This will get queued and then flushed via `app.sessionStart` at the end of initialization. The timestamp difference between the two events will be the cost of `ClientApp.Initialize`, about .2ms on my machine.