### PR TITLE
Client: Prevent NuGet deps from accidentally being marked explicit

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Client/ClientSession.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ClientSession.cs
@@ -601,7 +601,7 @@ namespace Xamarin.Interactive.Client
 
             var alreadyInstalledPackages = Workbook.Packages == null
                 ? ImmutableArray<InteractivePackage>.Empty
-                : Workbook.Packages.InstalledPackages.Where (p => p.IsExplicit);
+                : Workbook.Packages.InstalledPackages;
 
             Workbook.Packages = new InteractivePackageManager (
                 WorkbookApp.Sdk.TargetFramework,
@@ -615,6 +615,7 @@ namespace Xamarin.Interactive.Client
                 .Pages
                 .SelectMany (page => page.Packages)
                 .Concat (alreadyInstalledPackages)
+                .Where (p => p.IsExplicit)
                 .Distinct (PackageIdComparer.Default)
                 .ToArray ();
 

--- a/Clients/Xamarin.Interactive.Client/NuGet/InteractivePackageManager.cs
+++ b/Clients/Xamarin.Interactive.Client/NuGet/InteractivePackageManager.cs
@@ -427,7 +427,7 @@ namespace Xamarin.Interactive.NuGet
             // the same original version range string gets written to the manifest on save
             return new InteractivePackage (
                 packageIdentity,
-                isExplicit: originalInputPackage != null,
+                isExplicit: originalInputPackage?.IsExplicit == true,
                 assemblyReferences: assemblyReferences,
                 supportedVersionRange: originalInputPackage?.SupportedVersionRange);
         }


### PR DESCRIPTION
Rearrange the `InteractivePackage.IsExplicit` filtering in
`InitializePackagesAsync` so that `WorkbookPage.Packages` also gets
filtered. The latter is empty when a workbook is unsaved, but can
contain package deps when the workbook is saved.

The repro for this bug was:

1. Create a .NET Core workbook.
2. Add `System.Net.Http`.
3. Save.
4. Switch to Mono.
5. Witness giant package list.

Also fix the redundant check in
`InteractivePackageManager.GetInteractivePackageFromReader` to be more
correct. It shouldn't get hit now, though.