### PR TITLE
Build: Use a different Mac host for each Windows bot to avoid conflicts.

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -64,7 +64,8 @@
 
   <!-- XVS mac build host configuration (in VSTS) -->
   <PropertyGroup Condition="'$(TF_BUILD)' == 'True'">
-    <MacBuildHostAddress>bockover-1.guest.corp.microsoft.com</MacBuildHostAddress>
+    <MacBuildHostAddress Condition="'$(AGENT_NAME)' == 'RE Cambridge Windows-Inspector-1'">bockover-1.guest.corp.microsoft.com</MacBuildHostAddress>
+    <MacBuildHostAddress Condition="'$(AGENT_NAME)' == 'Cambridge Windows-Inspector-2'">inspector-1.guest.corp.microsoft.com</MacBuildHostAddress>
     <MacBuildHostUser>builder</MacBuildHostUser>
   </PropertyGroup>
 


### PR DESCRIPTION
Avoids issues with two builds trying to use the same Mac at the same time.