### PR TITLE
Add `netstandard` references to projects to make VSmac happy

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/Xamarin.Interactive.Client.Mac.csproj
+++ b/Clients/Xamarin.Interactive.Client.Mac/Xamarin.Interactive.Client.Mac.csproj
@@ -90,6 +90,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">

--- a/Clients/Xamarin.Interactive.Client/Xamarin.Interactive.Client.csproj
+++ b/Clients/Xamarin.Interactive.Client/Xamarin.Interactive.Client.csproj
@@ -18,6 +18,7 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.3.0" />


### PR DESCRIPTION
May need to restart VS after pulling this. Does not seem to work on
`Xamarin.Interactive.Tests.csproj` or
`Xamarin.Workbooks.Client.iOS.csproj` (which we don't build on Mac yet).