### PR TITLE
[UI][mac] Remove background color to show NSAddTemplate

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/Main.storyboard
+++ b/Clients/Xamarin.Interactive.Client.Mac/Main.storyboard
@@ -1491,11 +1491,6 @@ Gw
                                         <buttonCell key="cell" type="smallSquare" alternateTitle="Add" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" inset="2" id="gNj-ka-jpd">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="system"/>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                    <color key="value" red="0.99991267919540405" green="1" blue="0.99988144636154175" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </buttonCell>
                                         <connections>
                                             <action selector="addItem:" target="Z8w-yw-raT" id="27x-9L-x7i"/>


### PR DESCRIPTION
Remove button color attribute.

As shown in the image below the button is blacked out.
Remove color attribute, button is now displayed.

Before
<img width="500" alt="2017-11-16 9 08 00" src="https://user-images.githubusercontent.com/1955233/32866968-ae8c44e2-caad-11e7-88e0-4df051c6aa24.png">

After
<img width="500" alt="2017-11-16 9 04 29" src="https://user-images.githubusercontent.com/1955233/32866974-b515cb3a-caad-11e7-95c6-b03cc8f50ca7.png">
