### PR TITLE
Client: Allow agents to provide default warning suppressions

### DIFF
--- a/Agents/Xamarin.Interactive.DotNetCore/DotNetCoreAgent.cs
+++ b/Agents/Xamarin.Interactive.DotNetCore/DotNetCoreAgent.cs
@@ -6,6 +6,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 using Xamarin.Interactive.CodeAnalysis;
@@ -31,6 +33,16 @@ namespace Xamarin.Interactive.DotNetCore
 
         public override InspectView GetVisualTree (string hierarchyKind)
             => throw new NotSupportedException ();
+
+        internal override IEnumerable<string> GetReplDefaultWarningSuppressions ()
+            => base.GetReplDefaultWarningSuppressions ().Concat (new [] {
+                // Two assemblies with differing in release/version number. Most common with .NET Standard
+                // and PCL mixing versions.
+                "CS1701",
+                // Same type defined in multiple assemblies. Again related to .NET Standard
+                // and PCL mixing.
+                "CS1685"
+            });
 
         public override void LoadExternalDependencies (
             Assembly loadedAssembly,

--- a/Agents/Xamarin.Interactive/CodeAnalysis/EvaluationContextInitializeRequest.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/EvaluationContextInitializeRequest.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Interactive.CodeAnalysis
             var response = new TargetCompilationConfiguration ();
 
             response.DefaultUsings = agent.GetReplDefaultUsingNamespaces ().ToArray ();
+            response.DefaultWarningSuppressions = agent.GetReplDefaultWarningSuppressions ().ToArray ();
 
             var evaluationContext = agent.CreateEvaluationContext ();
             response.EvaluationContextId = evaluationContext.Id;

--- a/Agents/Xamarin.Interactive/CodeAnalysis/TargetCompilationConfiguration.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/TargetCompilationConfiguration.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Interactive.CodeAnalysis
         public string GlobalStateTypeName { get; set; }
         public AssemblyDefinition GlobalStateAssembly { get; set; }
         public string[] DefaultUsings { get; set; }
+        public string[] DefaultWarningSuppressions { get; set; }
         public int EvaluationContextId { get; set; }
     }
 }

--- a/Agents/Xamarin.Interactive/Core/Agent.cs
+++ b/Agents/Xamarin.Interactive/Core/Agent.cs
@@ -181,6 +181,9 @@ namespace Xamarin.Interactive.Core
             };
         }
 
+        internal virtual IEnumerable<string> GetReplDefaultWarningSuppressions ()
+            => Array.Empty<string> ();
+
         public abstract InspectView GetVisualTree (string hierarchyKind);
 
         public virtual InspectView HighlightView (double x, double y, bool clear, string hierarchyKind)

--- a/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/FilteredDiagnostics.cs
+++ b/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/FilteredDiagnostics.cs
@@ -35,6 +35,9 @@ namespace Xamarin.Interactive.Compilation.Roslyn
             var filteredDiagnostics = new List<Diagnostic> ();
 
             foreach (var d in diagnostics) {
+                if (d.IsSuppressed)
+                    continue;
+
                 HasWarnings |= d.Severity == DiagnosticSeverity.Warning;
                 HasErrors |= d.Severity == DiagnosticSeverity.Error;
                 if (filteredDiagnostics.Count < maxCount)

--- a/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/RoslynCompilationWorkspace.cs
+++ b/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/RoslynCompilationWorkspace.cs
@@ -321,7 +321,9 @@ namespace Xamarin.Interactive.Compilation.Roslyn
 
         readonly Type hostObjectType;
         readonly ImmutableArray<string> initialImports;
+        readonly ImmutableArray<string> initialWarningSuppressions;
         readonly ImmutableArray<PortableExecutableReference> initialReferences;
+        readonly ImmutableDictionary<string, ReportDiagnostic> initialDiagnosticOptions;
 
         readonly CSharpParseOptions parseOptions = new CSharpParseOptions (
             LanguageVersion.CSharp7_1,
@@ -361,6 +363,10 @@ namespace Xamarin.Interactive.Compilation.Roslyn
             this.hostObjectType = hostObjectType;
             EvaluationContextId = compilationConfiguration.EvaluationContextId;
             initialImports = compilationConfiguration.DefaultUsings.ToImmutableArray ();
+            initialWarningSuppressions = compilationConfiguration.DefaultWarningSuppressions.ToImmutableArray ();
+            initialDiagnosticOptions = initialWarningSuppressions.ToImmutableDictionary (
+                warningId => warningId,
+                warningId => ReportDiagnostic.Suppress);
             initialReferences = dependencyResolver.ResolveDefaultReferences ();
 
             var byNameImplicitReferences = new Tuple<string, Func<bool>> [] {
@@ -513,7 +519,8 @@ namespace Xamarin.Interactive.Compilation.Roslyn
                     usings: ImmutableArray<string>.Empty,
                     sourceReferenceResolver: sourceReferenceResolver,
                     metadataReferenceResolver: metadataReferenceResolver,
-                    assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default),
+                    assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default,
+                    specificDiagnosticOptions: initialDiagnosticOptions),
                 parseOptions: parseOptions,
                 documents: null,
                 hostObjectType: hostObjectType,


### PR DESCRIPTION
When using certain features with .NET Core (such as `dynamic`), or mixing PCLs and .NET Standard assemblies, warnings are produced that are purely cosmetic, like in #59.

Provide a way for agents to specify which warnings will be suppressed, pass the suppressions to Roslyn, and make sure that the client ignores suppressed diagnostics when reporting diagnostics.

Fixes #59. 