### PR TITLE
Add git-repo.ps1 to fetch the right ref for the proprietary repo

### DIFF
--- a/Build/git-repo.ps1
+++ b/Build/git-repo.ps1
@@ -1,0 +1,86 @@
+#!/usr/bin/env pwsh
+#
+# Author:
+#   Aaron Bockover <abock@microsoft.com>
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Param(
+  [Parameter(Mandatory = $true, Position = 1)]
+  [string]$DependenciesJsonPath,
+  [switch]$Update = $false,
+  [string]$GitHubToken
+)
+
+function CloneOrUpdate {
+  Param(
+    [Parameter(ValueFromPipeline)]$Dependency
+  )
+
+  $gitUrl = $Dependency.Name
+  $checkoutPath = $Dependency.Path
+  $gitRef = $Dependency.Version
+
+  if (-Not ($gitUrl -And $checkoutPath -And $gitRef)) {
+    Write-Error "Incomplete dependency object in ${DependenciesJsonPath}"
+    Write-Output $Dependency
+    Exit 1
+  }
+
+  $alreadyCloned = Test-Path -PathType Container $checkoutPath
+  if ($alreadyCloned -And -Not $Update) {
+    Write-Host $checkoutPath already exists and -Update was not specified
+    Return
+  }
+
+  # if HEAD points to a tag, assume the other repo has a matching tag;
+  # if it does not, then the checkout/update will fail
+  $tagRef = $(& git tag --points-at HEAD | Select-Object -First 1)
+  if ($tagRef) {
+    $gitRef = $tagRef
+  }
+
+  Write-Host "Cloning or updating:"
+  Write-Host "  -> URL:  $gitUrl"
+  Write-Host "  -> Ref:  $gitRef"
+  Write-Host "  -> Path: $checkoutPath"
+  Write-Host
+
+  if (-Not $alreadyCloned) {
+    & git clone $gitUrl $checkoutPath
+  }
+
+  Push-Location $checkoutPath
+  try {
+    if (-Not (& git checkout $gitRef)) {
+      Write-Error "Unable to check out $gitRef"
+      Exit 1
+    }
+    & git submodule sync
+    & git submodule update --recursive --init
+  } finally {
+    Pop-Location
+  }
+}
+
+if (-Not (Test-Path -PathType Leaf $DependenciesJsonPath)) {
+  Write-Error "$DependenciesJsonPath does not exist"
+  Exit 1
+}
+
+$DependenciesJsonDirectory = (Get-ChildItem $DependenciesJsonPath).DirectoryName
+
+(Get-Content -Raw $DependenciesJsonPath | ConvertFrom-Json) |
+  Where-Object { $_.Kind -Eq "GitRepo" } |
+  Foreach-Object {
+    $_.Path = [IO.Path]::Combine($DependenciesJsonDirectory, $_.Path)
+    if ($GitHubToken) {
+      $uri = New-Object -TypeName System.UriBuilder -ArgumentList $_.Name
+      if ($uri.Host -Eq "github.com") {
+        $uri.UserName = $GitHubToken
+        $_.Name = $uri.ToString()
+      }
+    }
+    Return $_
+  } | CloneOrUpdate

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,5 +1,11 @@
 [
   {
+    "Kind": "GitRepo",
+    "Name": "https://github.com/xamarin/workbooks-proprietary",
+    "Path": "workbooks-proprietary",
+    "Version": "master"
+  },
+  {
     "Kind": "NuGet",
     "Name": "MahApps.Metro",
     "Version": "1.3.0",


### PR DESCRIPTION
Because we can't use submodules for the proprietary repo that builds Xamarin.Android support, this annoying script does a poor job at emulating a submodule.

1. it operates on `GitRepo` objects from our `dependencies.json` (so at least everything is in one place)

2. it can inject a GitHub token into the URI, which comes from a secure variable in VSTS

3. if the ref being build in the main repo points to a tag, the ref in `dependencies.json` is discarded and the tag is used (e.g. the proprietary repo is tagged like the primary repo)

4. `-Update` can be passed to the script to reset the ref if it's already been checked out, but this is intentionally not default behavior

```bash
Build/git-repo.ps1 dependencies.json -Update -GitHubToken ********
```

This means that `UpdateInvertedDependencies` will now preserve `GitRepo` objects since it cannot generate them like the other object types.