### PR TITLE
Compilation: Fix custom attributes using types defined in the workbook

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/MonoScriptCompilationPatcher.cs
+++ b/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/MonoScriptCompilationPatcher.cs
@@ -112,7 +112,7 @@ namespace Xamarin.Interactive.Compilation.Roslyn
 
         /// <summary>
         /// Search the target byte array for an 8-byte magic value, then rewrite the string prefixed
-        /// by the magic value. Strings are terminated by '\0', '.', or '>'. This is very aggressive
+        /// by the magic value. Strings are terminated by '\0', '.', '>', or '+'. This is very aggressive
         /// and has nothing to do with the PE format, so the magic value should be very unique!
         /// </summary>
         static unsafe void Patch (byte [] target, byte [] magicBytes, PatchHandler patchHandler)
@@ -131,7 +131,7 @@ namespace Xamarin.Interactive.Compilation.Roslyn
                         var length = 8;
                         while (true) {
                             var b = target [i + length];
-                            if (b == 0 || b == '.' || b == '>')
+                            if (b == 0 || b == '.' || b == '>' || b == '+')
                                 break;
                             length++;
                         }

--- a/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/RoslynCompilationWorkspace.cs
+++ b/Clients/Xamarin.Interactive.Client/Compilation/Roslyn/RoslynCompilationWorkspace.cs
@@ -500,7 +500,7 @@ namespace Xamarin.Interactive.Compilation.Roslyn
             workspace.RemoveProject (project.Id);
         }
 
-        const string assemblyNamePrefix = "🐵 XIS";
+        const string assemblyNamePrefix = "🐵🐻";
         static readonly byte [] assemblyNamePrefixBytes = Encoding.UTF8.GetBytes (assemblyNamePrefix);
 
         ProjectInfo CreateSubmissionProjectInfo ()

--- a/Tests/Workbooks/Regression/Custom Attribute Types.workbook
+++ b/Tests/Workbooks/Regression/Custom Attribute Types.workbook
@@ -1,0 +1,26 @@
+---
+uti: com.xamarin.workbook
+id: 60f1e237-ac68-4dd6-8069-4f1ab3049a28
+title: Custom Attribute Types
+platforms:
+- Console
+---
+
+```csharp
+public class MyCustomAttribute : Attribute
+{
+    public Type TestType { get; set; }
+    public MyCustomAttribute(Type type) => TestType = type;
+}
+
+public class Foo {}
+
+public class Class
+{
+    [MyCustom(typeof(Foo))]
+    public string Foo { get; set; }
+}
+
+typeof(Class).GetMember("Foo").First().GetCustomAttributes(inherit: false)
+	.OfType<MyCustomAttribute>().First().TestType.AssemblyQualifiedName;
+```


### PR DESCRIPTION
Custom attributes (either from libraries or defined in the workbook itself) would cause the CLR
to throw `TypeLoadException` (with an empty type name!) when trying to load the type to create
the custom attribute instance, somewhere deep inside COM bits (I tracked it to CreateCaObject,
which is an internal call into the CLR).

Changing our assembly name prefix to not have any spaces fixed the initial submission (no
`TypeLoadException`, the correct output from the sample workbook in #104), but subsequent
submissions would throw `TypeLoadException` (this time with a non-bogus type name!) because
the assembly name had changed. 

The 2nd commit in the series fixes that as well, by improving the detection for when the assembly name has ended—the `+` used for nested classes wasn't being detected.

Adds the workbook from #104 as a regression workbook as well--this is a good test to have on hand,
as the kind of scenario this is likely to get hit in (JSON.Net + custom `JsonConverter`) is important.

Fixes #104.

#### To-do

- [x] Smoke test on Mac
  - [x] Console
  - [x] iOS
  - [x] .NET Core
  - [x] Android
  - [x] Mac Mobile
  - [x] Mac Full
- [x] Smoke test on Windows
  - [x] iOS
  - [x] Android
  - [x] WPF
  - [x] Console
  - [x] .NET Core