### PR TITLE
string-renderer.ts: use correct high surrogate start value

### DIFF
--- a/Clients/Xamarin.Interactive.Client/ClientApp/renderers/string-renderer.ts
+++ b/Clients/Xamarin.Interactive.Client/ClientApp/renderers/string-renderer.ts
@@ -86,7 +86,7 @@ export class StringRenderer implements Renderer {
         return "\\v";
       default:
         //print control and surrogate characters
-        if (charCode < 0x020 || (charCode >= 0xDC00 && charCode <= 0xDFFF) ||
+        if (charCode < 0x020 || (charCode >= 0xD800 && charCode <= 0xDFFF) ||
           // print all uncommon white spaces as numbers
           (/\s/.test(ch) && ch !== ' '))
           return "\\u" + ("000" + charCode.toString(16)).slice(-4);


### PR DESCRIPTION
This fixes a regression introduced in 1.3 around rendering C# string literals that contain emoji.