### PR TITLE
Client: Store last used workbook app and select it on startup.

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/NewWorkbookViewController.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/NewWorkbookViewController.cs
@@ -144,6 +144,7 @@ namespace Xamarin.Interactive.Client.Mac
         [Export ("createWorkbook:")]
         void CreateWorkbook (NSObject sender)
         {
+            viewController.SaveLastCreatedWorkbookPreference ();
             SessionDocumentController.SharedDocumentController.OpenDocument (
                 viewController.SelectedItem.CreateClientSessionUri ());
             ((NewWorkbookWindow)View.Window).Close (sender);

--- a/Clients/Xamarin.Interactive.Client.Windows/Views/NewWorkbookWindow.xaml.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/NewWorkbookWindow.xaml.cs
@@ -51,6 +51,7 @@ namespace Xamarin.Interactive.Client.Windows.Views
 
             AgentSessionWindow window = null;
             try {
+                viewController.SaveLastCreatedWorkbookPreference ();
                 window = AgentSessionWindow.Open (viewController.SelectedItem.CreateClientSessionUri ());
             } catch (Exception ex) {
                 Log.Error (TAG, ex);

--- a/Clients/Xamarin.Interactive.Client/Client/ViewControllers/NewWorkbookItem.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ViewControllers/NewWorkbookItem.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Interactive.Client.ViewControllers
                     true))
                 .ToArray ();
 
-            SelectedWorkbookApp = WorkbookApps [0];
+            selectedWorkbookApp = WorkbookApps [0];
         }
 
         void NotifyPropertyChanged ([CallerMemberName] string propertyName = null)

--- a/Clients/Xamarin.Interactive.Client/Client/ViewControllers/NewWorkbookViewController.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ViewControllers/NewWorkbookViewController.cs
@@ -5,31 +5,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-using Xamarin.Interactive.Client.AgentProcesses;
+using Newtonsoft.Json.Linq;
+
+using Xamarin.Interactive.Logging;
+using Xamarin.Interactive.Preferences;
 
 namespace Xamarin.Interactive.Client.ViewControllers
 {
     sealed class NewWorkbookViewController : INotifyPropertyChanged
     {
+        const string TAG = nameof (NewWorkbookViewController);
+
         public ReadOnlyCollection<NewWorkbookItem> Items { get; }
 
         public AgentType SelectedAgentType {
             get => SelectedItem?.SelectedWorkbookApp?.AgentType ?? AgentType.Unknown;
-            set {
-                foreach (var item in Items) {
-                    var app = item.WorkbookApps.FirstOrDefault (a => a.AgentType == value);
-                    if (app != null) {
-                        SelectedItem = item;
-                        item.SelectedWorkbookApp = app;
-                        return;
-                    }
-                }
-            }
+            set => SetSelectedItem (a => a.AgentType == value);
         }
 
         NewWorkbookItem selectedItem;
@@ -53,8 +51,61 @@ namespace Xamarin.Interactive.Client.ViewControllers
                 select new NewWorkbookItem (appGroup.First ().Icon, appGroup.Key, appGroup)
             ).ToList ());
 
-            if (Items.Count > 0)
-                SelectedItem = Items [0];
+            var lastUsedWorkbookApp = Prefs.UI.LastUsedWorkbookApp.GetValue ();
+            if (lastUsedWorkbookApp == null && Items.Count > 0)
+                selectedItem = Items [0];
+            else
+                LoadLastCreatedWorkbookPreference (lastUsedWorkbookApp);
+        }
+
+        public void SaveLastCreatedWorkbookPreference ()
+        {
+            try {
+                var lastUsedWorkbookApp = JToken.FromObject (new {
+                    id = SelectedItem.SelectedWorkbookApp.Id,
+                    optionalFeatures = SelectedItem.SelectedWorkbookApp.OptionalFeatures
+                        .Where (feature => feature.Enabled)
+                        .Select (feature => feature.Id)
+                }).ToString ();
+                Prefs.UI.LastUsedWorkbookApp.SetValue (lastUsedWorkbookApp);
+            } catch (Exception e) {
+                Log.Warning (TAG, "Could not save last used workbook app preference.", e);
+            }
+        }
+
+        void LoadLastCreatedWorkbookPreference (string lastUsedWorkbookAppJson)
+        {
+            JObject lastUsedWorkbookApp;
+
+            try {
+                lastUsedWorkbookApp = JObject.Parse (lastUsedWorkbookAppJson);
+
+                var id = lastUsedWorkbookApp.Value<string> ("id");
+                var optionalFeatures = new HashSet<string> (
+                    lastUsedWorkbookApp.Value<JArray> ("optionalFeatures").Values<string> ());
+
+                SetSelectedItem (wap => wap.Id == id);
+                selectedItem.SelectedWorkbookApp.OptionalFeatures.ForEach (feature => {
+                    if (optionalFeatures.Contains (feature.Id))
+                        feature.Enabled = true;
+                });
+            } catch (Exception e) {
+                Log.Warning (TAG, "Could not load last used workbook app from preferences.", e);
+                selectedItem = Items [0];
+                return;
+            }
+        }
+
+        void SetSelectedItem (Func<WorkbookAppViewController, bool> workbookAppFilter)
+        {
+            foreach (var item in Items) {
+                var app = item.WorkbookApps.FirstOrDefault (workbookAppFilter);
+                if (app != null) {
+                    SelectedItem = item;
+                    item.SelectedWorkbookApp = app;
+                    return;
+                }
+            }
         }
 
         void NotifyPropertyChanged ([CallerMemberName] string propertyName = null)

--- a/Clients/Xamarin.Interactive.Client/Client/ViewControllers/WorkbookAppViewController.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ViewControllers/WorkbookAppViewController.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Interactive.Client.ViewControllers
         public string Icon { get; }
         public bool Enabled { get; }
         public string Label { get; }
+        public string Id { get; }
         public IReadOnlyList<NewWorkbookFeature> OptionalFeatures { get; }
 
         public WorkbookAppViewController (
@@ -47,6 +48,7 @@ namespace Xamarin.Interactive.Client.ViewControllers
 
             AgentType = workbookApp.GetAgentType ();
 
+            Id = workbookApp.Id;
             Icon = workbookApp.Icon ?? "project";
             Enabled = enabled;
             Label = GetDisplayLabel (workbookApp, context);

--- a/Clients/Xamarin.Interactive.Client/Preferences/Prefs.cs
+++ b/Clients/Xamarin.Interactive.Client/Preferences/Prefs.cs
@@ -42,6 +42,9 @@ namespace Xamarin.Interactive.Preferences
                 public static readonly Preference<bool> UseHighContrast
                     = new Preference<bool> ("ui.theme.useHighContrast", false);
             }
+
+            public static readonly Preference<string> LastUsedWorkbookApp
+                = new Preference<string> ("ui.lastUsedWorkbookApp", null);
         }
 
         public static class Submissions


### PR DESCRIPTION
Sets the agent type when either the broader agent grouping or the more specific agent type within the grouping is set and changes constructors to use field setters instead of property setters to avoid side effects as necessary so that we don't update the preference all the time when constructing the items/controller.

Fixes #58.