### PR TITLE
Allow iOS coordinate mapper to work for Inspector and non-5s devices

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/CoordinateMappers/iOSSimulatorCoordinateMapper.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/CoordinateMappers/iOSSimulatorCoordinateMapper.cs
@@ -28,7 +28,8 @@ namespace Xamarin.Interactive.Client.Mac.CoordinateMappers
             //       sims open simultaneously.
             var window = InspectableWindow
                 .GetWindows ("com.apple.iphonesimulator")
-                .FirstOrDefault (w => w.Title != null && w.Title.Contains ("5s"));
+                .FirstOrDefault (w => w.Title != null &&
+                    (ClientInfo.Flavor == ClientFlavor.Inspector || w.Title.Contains ("5s")));
 
             if (window == null) {
                 Log.Error (TAG, "Unable to locate simulator window");


### PR DESCRIPTION
We only know it's a 5s in the case of Workbooks.

First part of fixing https://github.com/Microsoft/workbooks/issues/24.

Next will be passing more info to the client about what device was
launched.