### PR TITLE
Windows: Fix package dialog UI not drawing correctly after unlock

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Windows/Resources.xaml
+++ b/Clients/Xamarin.Interactive.Client.Windows/Resources.xaml
@@ -147,7 +147,7 @@
                             <Setter
                                 TargetName="ContentSite"
                                 Property="TextElement.Foreground"
-                                Value="{DynamicResource PrimaryContentSelectedTabForegroundBrush}"/>
+                                Value="{DynamicResource PrimaryContentHoverTabForegroundBrush}"/>
                             <Setter
                                 TargetName="Border"
                                 Property="Background"
@@ -167,6 +167,11 @@
     <Style x:Key="VisualTreeItemStyle" TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">
         <Setter Property="IsExpanded" Value="True" />
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ListViewSelectedForegroundBrush}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="OutlineViewItemStyle" TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource {x:Type TreeViewItem}}">

--- a/Clients/Xamarin.Interactive.Client.Windows/Themes/High Contrast.xaml
+++ b/Clients/Xamarin.Interactive.Client.Windows/Themes/High Contrast.xaml
@@ -103,6 +103,8 @@
     -->
     <SolidColorBrush x:Key="PrimaryContentSelectedTabForegroundBrush"
                      Color="{x:Static SystemColors.HighlightTextColor}" />
+    <SolidColorBrush x:Key="PrimaryContentHoverTabForegroundBrush"
+                     Color="{x:Static SystemColors.HighlightTextColor}" />
     <SolidColorBrush x:Key="PrimaryContentUnselectedTabForegroundBrush"
                      Color="{x:Static SystemColors.WindowTextColor}" />
     <SolidColorBrush x:Key="PrimaryContentSelectedTabBorderBrush"

--- a/Clients/Xamarin.Interactive.Client.Windows/Themes/Light.xaml
+++ b/Clients/Xamarin.Interactive.Client.Windows/Themes/Light.xaml
@@ -73,6 +73,7 @@
 
     <SolidColorBrush x:Key="PrimaryContentSelectedTabBorderBrush" Color="White" />
     <SolidColorBrush x:Key="PrimaryContentSelectedTabForegroundBrush" Color="Black" />
+    <SolidColorBrush x:Key="PrimaryContentHoverTabForegroundBrush" Color="White" />
     <SolidColorBrush x:Key="PrimaryContentUnselectedTabBorderBrush" Color="Transparent" />
     <SolidColorBrush x:Key="PrimaryContentUnselectedTabForegroundBrush" Color="White" />
     <SolidColorBrush x:Key="PrimaryContentInactiveSelectedTabForegroundBrush" Color="Black" />
@@ -98,7 +99,7 @@
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Trigger.Setters>
-                    <Setter Property="Foreground" Value="White" />
+                    <Setter Property="Foreground" Value="Black" />
                 </Trigger.Setters>
             </Trigger>
             <Trigger Property="IsSelected" Value="True">

--- a/Clients/Xamarin.Interactive.Client.Windows/Xamarin.Interactive.Client.Windows.csproj
+++ b/Clients/Xamarin.Interactive.Client.Windows/Xamarin.Interactive.Client.Windows.csproj
@@ -87,10 +87,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MahApps.Metro">
-      <Version>1.3.0</Version>
+      <Version>1.5.0</Version>
     </PackageReference>
     <PackageReference Include="MahApps.Metro.IconPacks.Material">
-      <Version>1.7.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="MouseKeyboardActivityMonitor">
       <Version>4.0.5150.10665</Version>


### PR DESCRIPTION
The package dialog UI (and theoretically, any other MahApps dialog UI) would not draw correctly after the OS was locked and unlocked--the UI would be working, but would be completely transparent.

Update MahApps to pull in the upstream bug fix (MahApps/MahApps.Metro#2734), and fix some small a11y/theming bugs that cropped up after the update.

Fixes #115.