### PR TITLE
Bundle Inspector clients into NuGet packages for IDE extensions

### DIFF
--- a/Agents/Xamarin.Interactive/InteractiveInstallation.cs
+++ b/Agents/Xamarin.Interactive/InteractiveInstallation.cs
@@ -41,7 +41,6 @@ namespace Xamarin.Interactive
         readonly string toolsInstallPath;
 
         public string BuildPath { get; }
-        public string WorkbookAppsInstallPath { get; }
 
         public bool IsMac { get; }
 
@@ -58,7 +57,6 @@ namespace Xamarin.Interactive
             workbooksClientInstallPath = installationPaths?.WorkbooksClientInstallPath;
             inspectorClientInstallPath = installationPaths?.InspectorClientInstallPath;
             agentsInstallPath = installationPaths?.AgentsInstallPath;
-            WorkbookAppsInstallPath = installationPaths?.WorkbookAppsInstallPath;
             toolsInstallPath = installationPaths?.ToolsInstallPath;
         }
 
@@ -96,7 +94,7 @@ namespace Xamarin.Interactive
 
         public string LocateSimChecker () => LocateSimCheckerExecutables ().FirstOrDefault ();
 
-        internal IReadOnlyList<string> LocateSimCheckerExecutables ()
+        IReadOnlyList<string> LocateSimCheckerExecutables ()
         {
             if (simCheckerExecutablePaths != null)
                 return simCheckerExecutablePaths;
@@ -112,71 +110,11 @@ namespace Xamarin.Interactive
             return simCheckerExecutablePaths;
         }
 
-        public string LocateAgentAssembly (AgentType agentType)
-            => LocateAgentAssemblies (agentType).FirstOrDefault ();
-
-        internal IReadOnlyList<string> LocateAgentAssemblies (AgentType agentType)
-        {
-            List<string> paths;
-            if (agentAssemblyPaths.TryGetValue (agentType, out paths))
-                return paths;
-
-            var searchPaths = new List<string> ();
-            if (agentsInstallPath != null)
-                searchPaths.Add (Path.Combine (agentsInstallPath, "Agents"));
-
-            string assemblyName = null;
-            switch (agentType) {
-            case AgentType.iOS:
-                assemblyName = "Xamarin.Interactive.iOS.dll";
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.iOS", "bin"));
-                break;
-            case AgentType.Android:
-                assemblyName = "Xamarin.Interactive.Android.dll";
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.Android.ActivityTrackerShim", "bin"));
-                break;
-            case AgentType.MacNet45:
-                assemblyName = "Xamarin.Interactive.Mac.Desktop.dll";
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.Mac.Desktop", "bin"));
-                break;
-            case AgentType.MacMobile:
-                assemblyName = "Xamarin.Interactive.Mac.Mobile.dll";
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.Mac.Mobile", "bin"));
-                break;
-            case AgentType.WPF:
-                assemblyName = "Xamarin.Interactive.Wpf.dll";
-                if (inspectorClientInstallPath != null)
-                    searchPaths.Add (inspectorClientInstallPath);
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.Wpf", "bin"));
-                break;
-            case AgentType.Console:
-                assemblyName = "Xamarin.Interactive.Console.exe";
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.Console", "bin"));
-                break;
-            case AgentType.DotNetCore:
-                assemblyName = "Xamarin.Interactive.DotNetCore.dll";
-                searchPaths.Add (Path.Combine (
-                    BuildPath, "Agents", "Xamarin.Interactive.DotNetCore", "bin"));
-                break;
-            default:
-                throw new ArgumentException ($"invalid AgentType: {agentType}", nameof (agentType));
-            }
-
-            agentAssemblyPaths.Add (agentType, paths = LocateFiles (searchPaths, assemblyName).ToList ());
-            return paths;
-        }
-
         public string LocateClientApplication (
             ClientSessionKind clientSessionKind = ClientSessionKind.LiveInspection)
             => LocateClientApplications (clientSessionKind).FirstOrDefault ();
 
-        internal IReadOnlyList<string> LocateClientApplications (ClientSessionKind clientSessionKind)
+        IReadOnlyList<string> LocateClientApplications (ClientSessionKind clientSessionKind)
         {
             if (clientAppPaths != null)
                 return clientAppPaths;

--- a/Agents/Xamarin.Interactive/InteractiveInstallationPaths.cs
+++ b/Agents/Xamarin.Interactive/InteractiveInstallationPaths.cs
@@ -14,30 +14,22 @@ namespace Xamarin.Interactive
         public string WorkbooksClientInstallPath { get; }
         public string InspectorClientInstallPath { get; }
         public string AgentsInstallPath { get; }
-        public string WorkbookAppsInstallPath { get; }
         public string ToolsInstallPath { get; }
 
         public InteractiveInstallationPaths (
-            string workbooksClientInstallPath,
-            string inspectorClientInstallPath,
             string agentsInstallPath,
-            string workbookAppsInstallPath,
-            string toolsInstallPath)
+            string workbooksClientInstallPath = null,
+            string inspectorClientInstallPath = null,
+            string toolsInstallPath = null)
         {
-            WorkbooksClientInstallPath = workbooksClientInstallPath
-                ?? throw new ArgumentNullException (nameof (workbooksClientInstallPath));
-
-            InspectorClientInstallPath = inspectorClientInstallPath
-                ?? throw new ArgumentNullException (nameof (inspectorClientInstallPath));
-
             AgentsInstallPath = agentsInstallPath
                 ?? throw new ArgumentNullException (nameof (agentsInstallPath));
 
-            WorkbookAppsInstallPath = workbookAppsInstallPath
-                ?? throw new ArgumentNullException (nameof (workbookAppsInstallPath));
+            WorkbooksClientInstallPath = workbooksClientInstallPath;
 
-            ToolsInstallPath = toolsInstallPath
-                ?? throw new ArgumentNullException (nameof (toolsInstallPath));
+            InspectorClientInstallPath = inspectorClientInstallPath;
+
+            ToolsInstallPath = toolsInstallPath;
         }
     }
 }

--- a/Build.proj
+++ b/Build.proj
@@ -50,6 +50,7 @@
     <InstallDestDir Condition="'$(InstallDestDir)' == ''">_install\</InstallDestDir>
     <PackageOutputDir Condition="'$(PackageOutputDir)' == ''">_artifacts\</PackageOutputDir>
     <InspectorNuGetPackageBuildDir>_inspectorPackage</InspectorNuGetPackageBuildDir>
+    <InspectorNuGetPackageContentDir>$(InspectorNuGetPackageBuildDir)\contentFiles\any\any\</InspectorNuGetPackageContentDir>
     <FrameworkInstallDir>$(InstallDestDir)Library\Frameworks\Xamarin.Interactive.framework\Versions\Current\</FrameworkInstallDir>
 
     <BuildInfoDistFile>Package/buildinfo</BuildInfoDistFile>
@@ -58,9 +59,14 @@
   <!-- Platform Specific Configuration -->
   <PropertyGroup Condition="'$(SolutionPlatform)' == 'Windows'">
     <UpdateInfoFile>Package\Windows\updateinfo</UpdateInfoFile>
+    <InspectorOutputPathSuffix>InspectorExe</InspectorOutputPathSuffix>
+    <InspectorPackageName>Xamarin.Inspector.Windows</InspectorPackageName>
+    <InspectorPackageNuspec>Package\Windows\$(InspectorPackageName).nuspec</InspectorPackageNuspec>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionPlatform)' == 'macOS'">
     <UpdateInfoFile>Package\Mac\updateinfo</UpdateInfoFile>
+    <InspectorPackageName>Xamarin.Inspector.Mac</InspectorPackageName>
+    <InspectorPackageNuspec>Package\Mac\$(InspectorPackageName).nuspec</InspectorPackageNuspec>
   </PropertyGroup>
 
   <!-- XVS mac build host configuration (in VSTS) -->
@@ -139,7 +145,7 @@
     <MSBuild
       BuildInParallel="true"
       Projects="Clients\Xamarin.Interactive.Client.Windows\Xamarin.Interactive.Client.Windows.csproj"
-      Properties="$(MSBuildCommonProperties);ClientOutputPathSuffix=InspectorExe;ClientAssemblyName=Xamarin Inspector;ClientDefineConstants=CLIENT_FLAVOR_INSPECTOR"
+      Properties="$(MSBuildCommonProperties);ClientOutputPathSuffix=$(InspectorOutputPathSuffix);ClientAssemblyName=Xamarin Inspector;ClientDefineConstants=CLIENT_FLAVOR_INSPECTOR"
       Targets="$(InteractiveBuildTarget)"/>
     <!-- Build everything else -->
     <MSBuild
@@ -248,6 +254,7 @@
     <MacDesktopAgentFiles Include="_build\$(Configuration)\WorkbookApps\Console\netstandard.dll"/>
     <ConsoleAgentFiles Include="Agents\Xamarin.Interactive.Console\bin\$(Configuration)\*"/>
     <DotNetCoreAgentFiles Include="Agents\Xamarin.Interactive.DotNetCore\bin\$(Configuration)\netstandard2.0\*"/>
+    <WpfAgentFiles Include="Agents\Xamarin.Interactive.Wpf\bin\$(Configuration)\Net45\*"/>
   </ItemGroup>
 
   <Target Name="_InstallAgentsMac">
@@ -355,8 +362,8 @@
       DestinationFolder="$(InspectorAppSharedSupportPath)"/>
 
     <!-- Copy completed Inspector.app bundle to staging area where Xamarin.Inspector.Mac.nupkg can be built later -->
-    <MakeDir Directories="$(InspectorNuGetPackageBuildDir)\contentFiles\any\any"/>
-    <Exec Command="cp -a &quot;$(InspectorClientInstallPath)\$(InspectorAppBundleName)&quot; &quot;$(InspectorNuGetPackageBuildDir)\contentFiles\any\any&quot;"/>
+    <MakeDir Directories="$(InspectorNuGetPackageContentDir)"/>
+    <Exec Command="cp -a &quot;$(InspectorClientInstallPath)\$(InspectorAppBundleName)&quot; &quot;$(InspectorNuGetPackageContentDir)&quot;"/>
   </Target>
 
   <Target Name="Package">
@@ -375,7 +382,7 @@
     <Message Text="Generated $(PackageOutputDir)buildinfo" Importance="high"/>
     <CallTarget Targets="PackageNuGet" Condition="'$(SolutionPlatform)' == 'macOS'"/>
     <CallTarget Targets="_PackageInspectorNuGetMac" Condition="'$(SolutionPlatform)' == 'macOS'"/>
-    <!--<CallTarget Targets="_PackageInspectorNuGetWin" Condition="'$(SolutionPlatform)' == 'Windows'"/>-->
+    <CallTarget Targets="_PackageInspectorNuGetWin" Condition="'$(SolutionPlatform)' == 'Windows'"/>
     <CallTarget Targets="GenerateReleaseNotes" Condition="'$(SolutionPlatform)' == 'macOS'"/>
   </Target>
 
@@ -466,19 +473,61 @@
   </Target>
 
   <Target Name="_PackageInspectorNuGetMac" DependsOnTargets="Xamarin_Build_ReadAllProperties;Install">
+    <CallTarget Targets="_DoPackageInspectorNuGet"/>
+  </Target>
+
+  <Target Name="_PackageInspectorNuGetWin" DependsOnTargets="Xamarin_Build_ReadAllProperties">
+    <ItemGroup>
+      <InspectorClientFiles Include="Clients\Xamarin.Interactive.Client.Windows\bin\$(Configuration)$(InspectorOutputPathSuffix)\**\*"/>
+    </ItemGroup>
     <PropertyGroup>
-      <InspectorPackageName>Xamarin.Inspector.Mac</InspectorPackageName>
+      <!-- Add a parent folder since there's no app bundle like on Mac -->
+      <InspectorNuGetPackageWindowsContentDir>$(InspectorNuGetPackageContentDir)\Xamarin.Inspector.Windows\</InspectorNuGetPackageWindowsContentDir>
+    </PropertyGroup>
+
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(InspectorClientFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Client\%(RecursiveDir)"/>
+
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(AndroidAgentFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Agents\Android"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(iOSAgentFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Agents\iOS"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(WpfAgentFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Agents\WPF"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(AndroidFormsAgentFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Agents\Forms\Android"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(iOSFormsAgentFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Agents\Forms\iOS"/>
+
+    <CallTarget Targets="_DoPackageInspectorNuGet"/>
+  </Target>
+
+  <Target Name="_DoPackageInspectorNuGet" DependsOnTargets="Xamarin_Build_ReadAllProperties">
+    <PropertyGroup>
       <InspectorPackageFileName>$(InspectorPackageName).$(ReleaseVersion_SemVerNuGetSafe).nupkg</InspectorPackageFileName>
     </PropertyGroup>
+
     <Error Text="NuGet is not provisioned" Condition="!Exists('$(NuGet)')"/>
     <Copy
       SkipUnchangedFiles="true"
-      SourceFiles="Package\Mac\$(InspectorPackageName).nuspec"
+      SourceFiles="$(InspectorPackageNuspec)"
       DestinationFolder="$(InspectorNuGetPackageBuildDir)"/>
     <!-- Use SemVerNuGetSafe to get versions in the form of x.y.z-beta1-build.123 instead of x.y.z-beta1+123.
          NuGet does not support reading build numbers from semver metadata. -->
     <Exec
-      Command="$(NuGet) pack $(InspectorPackageName).nuspec -Version $(ReleaseVersion_SemVerNuGetSafe) -NoPackageAnalysis"
+      Command="&quot;$(NuGet)&quot; pack $(InspectorPackageName).nuspec -Version $(ReleaseVersion_SemVerNuGetSafe) -NoPackageAnalysis"
       WorkingDirectory="$(InspectorNuGetPackageBuildDir)"/>
     <Copy
       SourceFiles="$(InspectorNuGetPackageBuildDir)\$(InspectorPackageFileName)"
@@ -490,7 +539,7 @@
       <Pdbs Include="Agents\**\bin\$(Configuration)\**\*.pdb" />
       <Pdbs Include="Clients\**\bin\$(Configuration)\*.pdb" />
       <Pdbs Include="WorkbookApps\**\bin\$(Configuration)\*.pdb" />
-      <Pdbs Include="Clients\Xamarin.Interactive.Client.Windows\bin\$(Configuration)InspectorExe\Xamarin Inspector.pdb" />
+      <Pdbs Include="Clients\Xamarin.Interactive.Client.Windows\bin\$(Configuration)$(InspectorOutputPathSuffix)\Xamarin Inspector.pdb" />
     </ItemGroup>
     <PropertyGroup>
       <PdbArchiveName>XamarinInteractive-PDB-$(ReleaseVersion_SemVer).zip</PdbArchiveName>

--- a/Build.proj
+++ b/Build.proj
@@ -284,10 +284,6 @@
       DestinationFolder="$(FrameworkInstallDir)Agents\DotNetCore"/>
   </Target>
 
-  <ItemGroup>
-    <SimCheckerFiles Include="Clients\Xamarin.Interactive.Client.Mac.SimChecker\bin\$(Configuration)\*"/>
-  </ItemGroup>
-
   <Target Name="_InstallClientAppMac">
     <PropertyGroup>
       <WorkbooksAppBundleName>Xamarin Workbooks.app</WorkbooksAppBundleName>

--- a/Build.proj
+++ b/Build.proj
@@ -49,6 +49,7 @@
 
     <InstallDestDir Condition="'$(InstallDestDir)' == ''">_install\</InstallDestDir>
     <PackageOutputDir Condition="'$(PackageOutputDir)' == ''">_artifacts\</PackageOutputDir>
+    <InspectorNuGetPackageBuildDir>_inspectorPackage</InspectorNuGetPackageBuildDir>
     <FrameworkInstallDir>$(InstallDestDir)Library\Frameworks\Xamarin.Interactive.framework\Versions\Current\</FrameworkInstallDir>
 
     <BuildInfoDistFile>Package/buildinfo</BuildInfoDistFile>
@@ -287,17 +288,75 @@
   <Target Name="_InstallClientAppMac">
     <PropertyGroup>
       <WorkbooksAppBundleName>Xamarin Workbooks.app</WorkbooksAppBundleName>
+      <InspectorAppBundleName>Xamarin Inspector.app</InspectorAppBundleName>
+      <InspectorClientInstallPath>$(FrameworkInstallDir)InspectorClient\</InspectorClientInstallPath>
       <WorkbooksAppBundlePath>Clients\Xamarin.Interactive.Client.Mac\bin\$(Configuration)\$(WorkbooksAppBundleName)</WorkbooksAppBundlePath>
-      <InspectorAppBundlePath>Clients\Xamarin.Interactive.Client.Mac\bin\$(Configuration)\Xamarin Inspector.app</InspectorAppBundlePath>
+      <InspectorAppBundlePath>Clients\Xamarin.Interactive.Client.Mac\bin\$(Configuration)\$(InspectorAppBundleName)</InspectorAppBundlePath>
+      <WorkbooksAppSharedSupportPath>$(InstallDestDir)Applications\$(WorkbooksAppBundleName)\Contents\SharedSupport\</WorkbooksAppSharedSupportPath>
+      <InspectorAppSharedSupportPath>$(InspectorClientInstallPath)$(InspectorAppBundleName)\Contents\SharedSupport\</InspectorAppSharedSupportPath>
     </PropertyGroup>
 
+    <!-- Install Workbooks.app -->
     <MakeDir Directories="$(InstallDestDir)Applications"/>
     <Exec Command="cp -a &quot;$(WorkbooksAppBundlePath)&quot; &quot;$(InstallDestDir)Applications&quot;"/>
     <MakeDir Directories="$(InstallDestDir)Applications\$(WorkbooksAppBundleName)\Contents\SharedSupport"/>
-    <Exec Command="cp -a &quot;_build\$(Configuration)\WorkbookApps&quot; &quot;$(InstallDestDir)Applications\$(WorkbooksAppBundleName)\Contents\SharedSupport&quot;"/>
+    <Exec Command="cp -a &quot;_build\$(Configuration)\WorkbookApps&quot; &quot;$(WorkbooksAppSharedSupportPath)&quot;"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(AndroidFormsAgentFiles)"
+      DestinationFolder="$(WorkbooksAppSharedSupportPath)Agents\Forms\Android"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(iOSFormsAgentFiles)"
+      DestinationFolder="$(WorkbooksAppSharedSupportPath)Agents\Forms\iOS"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="$(UpdateInfoFile)"
+      DestinationFolder="$(WorkbooksAppSharedSupportPath)"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="$(BuildInfoDistFile)"
+      DestinationFolder="$(WorkbooksAppSharedSupportPath)"/>
 
-    <MakeDir Directories="$(FrameworkInstallDir)InspectorClient"/>
-    <Exec Command="cp -a &quot;$(InspectorAppBundlePath)&quot; &quot;$(FrameworkInstallDir)InspectorClient&quot;"/>
+    <!-- Install Inspector.app in old location -->
+    <MakeDir Directories="$(InspectorClientInstallPath)"/>
+    <Exec Command="cp -a &quot;$(InspectorAppBundlePath)&quot; &quot;$(InspectorClientInstallPath)&quot;"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(AndroidAgentFiles)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)Agents\Android"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(iOSAgentFiles)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)Agents\iOS"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(MacMobileAgentFiles)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)Agents\Mac\Mobile"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(MacDesktopAgentFiles)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)Agents\Mac\Desktop"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(AndroidFormsAgentFiles)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)Agents\Forms\Android"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(iOSFormsAgentFiles)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)Agents\Forms\iOS"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="$(UpdateInfoFile)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="$(BuildInfoDistFile)"
+      DestinationFolder="$(InspectorAppSharedSupportPath)"/>
+
+    <!-- Copy completed Inspector.app bundle to staging area where Xamarin.Inspector.Mac.nupkg can be built later -->
+    <MakeDir Directories="$(InspectorNuGetPackageBuildDir)\contentFiles\any\any"/>
+    <Exec Command="cp -a &quot;$(InspectorClientInstallPath)\$(InspectorAppBundleName)&quot; &quot;$(InspectorNuGetPackageBuildDir)\contentFiles\any\any&quot;"/>
   </Target>
 
   <Target Name="Package">
@@ -315,6 +374,8 @@
       DestinationFolder="$(PackageOutputDir)"/>
     <Message Text="Generated $(PackageOutputDir)buildinfo" Importance="high"/>
     <CallTarget Targets="PackageNuGet" Condition="'$(SolutionPlatform)' == 'macOS'"/>
+    <CallTarget Targets="_PackageInspectorNuGetMac" Condition="'$(SolutionPlatform)' == 'macOS'"/>
+    <!--<CallTarget Targets="_PackageInspectorNuGetWin" Condition="'$(SolutionPlatform)' == 'Windows'"/>-->
     <CallTarget Targets="GenerateReleaseNotes" Condition="'$(SolutionPlatform)' == 'macOS'"/>
   </Target>
 
@@ -402,6 +463,26 @@
     <Copy
         SourceFiles="Agents\Xamarin.Interactive\Xamarin.Workbooks.Integration.$(WorkbooksIntegrationNuGetPackageVersion).nupkg"
         DestinationFiles="$(PackageOutputDir)\Xamarin.Workbooks.Integration.$(WorkbooksIntegrationNuGetPackageVersion).nupkg" />
+  </Target>
+
+  <Target Name="_PackageInspectorNuGetMac" DependsOnTargets="Xamarin_Build_ReadAllProperties;Install">
+    <PropertyGroup>
+      <InspectorPackageName>Xamarin.Inspector.Mac</InspectorPackageName>
+      <InspectorPackageFileName>$(InspectorPackageName).$(ReleaseVersion_SemVerNuGetSafe).nupkg</InspectorPackageFileName>
+    </PropertyGroup>
+    <Error Text="NuGet is not provisioned" Condition="!Exists('$(NuGet)')"/>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="Package\Mac\$(InspectorPackageName).nuspec"
+      DestinationFolder="$(InspectorNuGetPackageBuildDir)"/>
+    <!-- Use SemVerNuGetSafe to get versions in the form of x.y.z-beta1-build.123 instead of x.y.z-beta1+123.
+         NuGet does not support reading build numbers from semver metadata. -->
+    <Exec
+      Command="$(NuGet) pack $(InspectorPackageName).nuspec -Version $(ReleaseVersion_SemVerNuGetSafe) -NoPackageAnalysis"
+      WorkingDirectory="$(InspectorNuGetPackageBuildDir)"/>
+    <Copy
+      SourceFiles="$(InspectorNuGetPackageBuildDir)\$(InspectorPackageFileName)"
+      DestinationFiles="$(PackageOutputDir)\$(InspectorPackageFileName)"/>
   </Target>
 
   <Target Name="_PackagePdbs" DependsOnTargets="Xamarin_Build_ReadAllProperties">

--- a/Build/Metadata.targets
+++ b/Build/Metadata.targets
@@ -37,6 +37,11 @@ Copyright 2017 Microsoft. All rights reserved.
         TaskParameter="Value"
         PropertyName="ReleaseVersion_SemVer"/>
     </CreateProperty>
+    <CreateProperty Value="$(PackageDotJson_Version)-build.$(CommonGitInfo_MinMaxCommitDistance)">
+      <Output
+        TaskParameter="Value"
+        PropertyName="ReleaseVersion_SemVerNuGetSafe"/>
+    </CreateProperty>
     <CreateProperty Value="$(CommonGitInfo_MaxRevisionTimestamp)">
       <Output
         TaskParameter="Value"

--- a/Clients/Xamarin.Interactive.Client.Mac/Main.storyboard
+++ b/Clients/Xamarin.Interactive.Client.Mac/Main.storyboard
@@ -206,7 +206,6 @@ Gw
                 <tabViewController selectedTabViewItemIndex="0" tabStyle="toolbar" id="XgF-AY-gyd" customClass="PreferencesTabViewController" sceneMemberID="viewController">
                     <tabViewItems>
                         <tabViewItem label="General" identifier="" image="NSPreferencesGeneral" id="751-Qr-6yV"/>
-                        <tabViewItem label="Updates" image="preferences-updates-32" id="cUh-6e-Fy4"/>
                         <tabViewItem label="Feedback" image="preferences-feedback-32" id="zrc-su-VN4"/>
                     </tabViewItems>
                     <viewControllerTransitionOptions key="transitionOptions" allowUserInteraction="YES"/>
@@ -219,7 +218,6 @@ Gw
                     <connections>
                         <outlet property="tabView" destination="3cz-ac-hco" id="SUO-s3-xvG"/>
                         <segue destination="5cL-NK-hn5" kind="relationship" relationship="tabItems" id="VzD-a9-7fm"/>
-                        <segue destination="s65-8V-v1T" kind="relationship" relationship="tabItems" id="Hll-fo-JJQ"/>
                         <segue destination="sNN-bw-8fp" kind="relationship" relationship="tabItems" id="Wj9-Ui-FRl"/>
                     </connections>
                 </tabViewController>
@@ -429,7 +427,7 @@ Gw
         <!--Preferences Updater View Controller-->
         <scene sceneID="why-Gl-ECy">
             <objects>
-                <viewController id="s65-8V-v1T" customClass="PreferencesUpdaterViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PreferencesUpdaterViewController" id="s65-8V-v1T" customClass="PreferencesUpdaterViewController" sceneMemberID="viewController">
                     <view key="view" id="iYV-MS-bjK" customClass="PreferencesView">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="159"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -644,18 +642,6 @@ Gw
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="showAbout:" target="Voe-Tx-rLC" id="4hD-os-eEc"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Check for Updates…" id="zNo-k9-1Cf">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="checkForUpdates:" target="Voe-Tx-rLC" id="maq-k1-ehl"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Enable Terminal Usage…" id="xlZ-EV-ZKg">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="installCommandLineTool:" target="Ady-hI-5gd" id="vRc-rh-XKW"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>

--- a/Clients/Xamarin.Interactive.Client.Mac/Preferences/PreferencesWindowController.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/Preferences/PreferencesWindowController.cs
@@ -11,6 +11,7 @@ using AppKit;
 using CoreGraphics;
 using Foundation;
 
+using Xamarin.Interactive.Client;
 using Xamarin.Interactive.I18N;
 
 namespace Xamarin.Interactive.Preferences
@@ -30,6 +31,15 @@ namespace Xamarin.Interactive.Preferences
         public override void WindowDidLoad ()
         {
             base.WindowDidLoad ();
+
+            if (ClientInfo.Flavor != ClientFlavor.Inspector)
+                ContentViewController.InsertTabViewItem (new NSTabViewItem {
+                    Label = Catalog.GetString ("Updates"),
+                    Image = NSImage.ImageNamed ("preferences-updates-32"),
+                    ViewController = NSStoryboard
+                        .FromName ("Main", NSBundle.MainBundle)
+                        .InstantiateController<PreferencesUpdaterViewController> ()
+                }, 1);
 
             if (WebKitPrefs.DeveloperExtrasEnabled)
                 ContentViewController.AddTabViewItem (new NSTabViewItem {

--- a/Clients/Xamarin.Interactive.Client.Mac/Xamarin.Interactive.Client.Mac.csproj
+++ b/Clients/Xamarin.Interactive.Client.Mac/Xamarin.Interactive.Client.Mac.csproj
@@ -388,9 +388,6 @@
     <BundleResource Include="Resources\refresh-16%402x.png" />
     <BundleResource Include="Resources\cancel-16.png" />
     <BundleResource Include="Resources\cancel-16%402x.png" />
-    <BundleResource Include="..\..\Package\buildinfo">
-      <Link>Resources\buildinfo</Link>
-    </BundleResource>
     <BundleResource Include="Resources\project-16.png" />
     <BundleResource Include="Resources\project-16%402x.png" />
     <BundleResource Include="Resources\project-android-16.png" />
@@ -401,9 +398,6 @@
     <BundleResource Include="Resources\project-ios-16%402x.png" />
     <BundleResource Include="Resources\project-macos-16.png" />
     <BundleResource Include="Resources\project-macos-16%402x.png" />
-    <BundleResource Include="..\..\Package\Mac\updateinfo">
-      <Link>Resources\updateinfo</Link>
-    </BundleResource>
     <BundleResource Include="Resources\preferences-feedback-32.png" />
     <BundleResource Include="Resources\preferences-feedback-32%402x.png" />
     <BundleResource Include="Resources\preferences-updates-32.png" />

--- a/Clients/Xamarin.Interactive.Client.Windows/App.xaml.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/App.xaml.cs
@@ -168,8 +168,9 @@ namespace Xamarin.Interactive.Client.Windows
 
             base.OnStartup (e);
 
-            ClientApp.SharedInstance.Updater.CheckForUpdatesPeriodicallyInBackground (
-                update => UpdateHandler (null, update));
+            if (ClientInfo.Flavor != ClientFlavor.Inspector)
+                ClientApp.SharedInstance.Updater.CheckForUpdatesPeriodicallyInBackground (
+                    update => UpdateHandler (null, update));
         }
 
         public static void CheckForUpdatesInBackground (Window ownerWindow = null, bool userInitiated = false)
@@ -188,6 +189,9 @@ namespace Xamarin.Interactive.Client.Windows
 
         static void UpdateHandler (Window ownerWindow, Task<UpdateItem> update)
         {
+            if (ClientInfo.Flavor == ClientFlavor.Inspector)
+                return;
+
             if (update.IsFaulted) {
                 if (ownerWindow != null)
                     update.Exception.ToUserPresentable (

--- a/Clients/Xamarin.Interactive.Client.Windows/Views/MenuManager.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/MenuManager.cs
@@ -191,11 +191,12 @@ namespace Xamarin.Interactive.Client.Windows.Views
                 Command = Commands.Commands.Help,
             });
 
-            helpMenu.Items.Add (new MenuItem {
-                Header = "Check for Updates",
-                Command = Commands.Commands.CheckForUpdates,
-                CommandParameter = window
-            });
+            if (ClientInfo.Flavor != ClientFlavor.Inspector)
+                helpMenu.Items.Add (new MenuItem {
+                    Header = "Check for Updates",
+                    Command = Commands.Commands.CheckForUpdates,
+                    CommandParameter = window
+                });
 
             helpMenu.Items.Add (new Separator ());
 

--- a/Clients/Xamarin.Interactive.Client.Windows/Views/OptionsWindow.xaml
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/OptionsWindow.xaml
@@ -113,7 +113,8 @@
         <TabItem
             Style="{DynamicResource TabItemStyle}"
             Foreground="{DynamicResource TextBrush}"
-            Header="updates">
+            Header="updates"
+            Visibility="{Binding IsInspectorClient, Converter={StaticResource visibilityConverter}, ConverterParameter=Inverse}">
             <Grid IsSharedSizeScope="True">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>

--- a/Clients/Xamarin.Interactive.Client.Windows/WindowsClientApp.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/WindowsClientApp.cs
@@ -167,5 +167,16 @@ namespace Xamarin.Interactive.Client
 
         protected override UpdaterService CreateUpdaterService ()
             => new UpdaterService ("win", "201185fb-fefe-4996-bdfe-4b6ac311a73b");
+
+        protected override void OnInitialized ()
+        {
+            var workbookAppsDirectory = new FilePath (Assembly.GetExecutingAssembly ().Location)
+                .ParentDirectory
+                .ParentDirectory
+                .Combine ("WorkbookApps");
+
+            if (workbookAppsDirectory.DirectoryExists)
+                WorkbookAppInstallation.RegisterSearchPath (workbookAppsDirectory);
+        }
     }
 }

--- a/Clients/Xamarin.Interactive.Client/WorkbookAppInstallation.cs
+++ b/Clients/Xamarin.Interactive.Client/WorkbookAppInstallation.cs
@@ -243,7 +243,6 @@ namespace Xamarin.Interactive
 
         static IReadOnlyList<WorkbookAppInstallation> LocateWorkbookApps ()
         {
-            searchPaths.Add (InteractiveInstallation.Default.WorkbookAppsInstallPath);
             searchPaths.Add (Path.Combine (InteractiveInstallation.Default.BuildPath, "_build"));
 
             var manifestFile = InteractiveInstallation

--- a/Package/Mac/Xamarin.Inspector.Mac.nuspec
+++ b/Package/Mac/Xamarin.Inspector.Mac.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package>
+  <metadata minClientVersion="3.3.0">
+    <id>Xamarin.Inspector.Mac</id>
+    <version>0.0.0</version>
+    <title>Xamarin Inspector Extension Support for Mac</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <developmentDependency>true</developmentDependency>
+    <description>Xamarin Inspector client and support files for IDE extensions.</description>
+    <copyright>Copyright 2017 Microsoft. All rights reserved.</copyright>
+    <tags>xamarin inspector</tags>
+    <contentFiles>
+        <files
+            include="any/**"
+            buildAction="None"
+            copyToOutput="true" />
+    </contentFiles>
+  </metadata>
+</package>

--- a/Package/Windows/Xamarin.Inspector.Windows.nuspec
+++ b/Package/Windows/Xamarin.Inspector.Windows.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package>
+  <metadata minClientVersion="3.3.0">
+    <id>Xamarin.Inspector.Windows</id>
+    <version>0.0.0</version>
+    <title>Xamarin Inspector Extension Support for Windows</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <developmentDependency>true</developmentDependency>
+    <description>Xamarin Inspector client and support files for IDE extensions.</description>
+    <copyright>Copyright 2017 Microsoft. All rights reserved.</copyright>
+    <tags>xamarin inspector</tags>
+    <contentFiles>
+        <files
+            include="any/**"
+            buildAction="None"
+            copyToOutput="true" />
+    </contentFiles>
+  </metadata>
+</package>

--- a/Tests/Xamarin.Interactive.Tests.InspectorSupport.Mac/Main.cs
+++ b/Tests/Xamarin.Interactive.Tests.InspectorSupport.Mac/Main.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Runtime.InteropServices;
@@ -43,18 +44,19 @@ namespace Xamarin.Interactive.Tests.InspectorSupport.Mac
             for (int i = 0; i < 8; i++)
                 buildRoot = Path.GetDirectoryName (buildRoot);
 
-            InteractiveInstallation.InitializeDefault (true, buildRoot);
-
-            var agentAssemblyPath = InteractiveInstallation.Default.LocateAgentAssembly (
-                AgentType.MacMobile);
+            var agentAssemblyPath = InteractiveInstallation.LocateFiles (
+                new [] { Path.Combine (buildRoot, "Agents", "Xamarin.Interactive.Mac.Mobile", "bin") },
+                "Xamarin.Interactive.Mac.Mobile.dll").First ();
 
             Console.WriteLine ("Injecting Agent Assembly");
             Console.WriteLine ($"  path:  {agentAssemblyPath}");
             Console.WriteLine ($"  mtime: {File.GetLastWriteTime (agentAssemblyPath)}");
 
-            Assembly.LoadFrom (Path.Combine (
-                Path.GetDirectoryName (InteractiveInstallation.Default.LocateAgentAssembly (AgentType.Console)),
-                "netstandard.dll"));
+            var netstandardAssemblyPath = InteractiveInstallation.LocateFiles (
+                new [] { Path.Combine (buildRoot, "Agents", "Xamarin.Interactive.Console", "bin") },
+                "netstandard.dll").First ();
+
+            Assembly.LoadFrom (netstandardAssemblyPath);
 
             inspectorSupportType = Assembly
                 .LoadFrom (agentAssemblyPath)


### PR DESCRIPTION
This is the first step to fixing https://github.com/Microsoft/workbooks/issues/23.

Both `Xamarin Workbooks.app` and `Xamarin Inspector.app` now have all files they need directly in the app bundle, instead of depending on `/Library/Frameworks/Xamarin.Interactive.framework`. Specifically, forms support and (in the case of Inspector) agent assemblies have been moved to `SharedSupport/Agents`. We can remove `Xamarin.Interactive.framework` as soon as we're ready to drop 15.5 support.

`updateinfo` and `buildinfo` have moved from `Resources` to `SharedSupport` within the app bundles.

Our package build now also generates a `Xamarin.Inspector.Mac` NuGet package, which can be consumed by the VSmac Inspector extension, so that the extension will no longer require a compatible installation of Xamarin Workbooks.

A corresponding `Xamarin.Inspector.Windows` NuGet package for VS has also been added, with no changes to the workbooks client install.

`InteractiveInstallation` has been trimmed down to reflect the fact that we don't need to locate agent files (or clients) from either client app. On Windows and Mac, "installed" items are found relative to the client exe, instead of using absolute framework paths or checking registry keys.

Update checking has been disabled in all Inspector clients.