### PR TITLE
Forms: Bump to latest stable (2.5.0).

### DIFF
--- a/Agents/Xamarin.Interactive.Forms.Android/Xamarin.Interactive.Forms.Android.csproj
+++ b/Agents/Xamarin.Interactive.Forms.Android/Xamarin.Interactive.Forms.Android.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.4.0.38779</Version>
+      <Version>2.5.0.121934</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Agents/Xamarin.Interactive.Forms.iOS/Xamarin.Interactive.Forms.iOS.csproj
+++ b/Agents/Xamarin.Interactive.Forms.iOS/Xamarin.Interactive.Forms.iOS.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.4.0.38779</Version>
+      <Version>2.5.0.121934</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Agents/Xamarin.Interactive.Forms/Xamarin.Interactive.Forms.csproj
+++ b/Agents/Xamarin.Interactive.Forms/Xamarin.Interactive.Forms.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.4.0.38779" />
+    <PackageReference Include="Xamarin.Forms" Version="2.5.0.121934" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clients/Xamarin.Interactive.Client/Client/ClientSession.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ClientSession.cs
@@ -679,6 +679,7 @@ namespace Xamarin.Interactive.Client
                     package.Identity.Version.Version,
                     this,
                     CompilationWorkspace.DependencyResolver,
+                    CompilationWorkspace.EvaluationContextId,
                     Agent.IncludePeImage);
             }
 

--- a/Clients/Xamarin.Interactive.Client/Compilation/CompilationWorkspaceFactory.cs
+++ b/Clients/Xamarin.Interactive.Client/Compilation/CompilationWorkspaceFactory.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Interactive.Compilation
                         formsReference.Name.Version,
                         clientSession,
                         dependencyResolver,
+                        configuration.EvaluationContextId,
                         includePeImage).ConfigureAwait (false);
             }
 
@@ -80,6 +81,7 @@ namespace Xamarin.Interactive.Compilation
             Version formsVersion,
             ClientSession clientSession,
             DependencyResolver dependencyResolver,
+            int evaluationContextId,
             bool includePeImage)
         {
             var formsAssembly = InteractiveInstallation.Default.LocateFormsAssembly (
@@ -124,7 +126,7 @@ namespace Xamarin.Interactive.Compilation
             }).ToArray ();
 
             var res = await clientSession.Agent.Api.LoadAssembliesAsync (
-                clientSession.CompilationWorkspace.EvaluationContextId,
+                evaluationContextId,
                 assembliesToLoad);
 
             var failed = res.LoadResults.Where (p => !p.Success);

--- a/Clients/Xamarin.Interactive.Client/NuGet/InteractivePackageManager.cs
+++ b/Clients/Xamarin.Interactive.Client/NuGet/InteractivePackageManager.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Interactive.NuGet
 
         internal static readonly PackageIdentity FixedXamarinFormsPackageIdentity = new PackageIdentity (
             "Xamarin.Forms",
-            new NuGetVersion (2, 4, 0, 38779));
+            new NuGetVersion (2, 5, 0, 121934));
 
         readonly NuGetPackageManager packageManager;
         readonly InteractivePackageProjectContext projectContext;

--- a/Package/Windows/AndroidAgentAppAssemblies.wxs
+++ b/Package/Windows/AndroidAgentAppAssemblies.wxs
@@ -689,6 +689,30 @@
       <Component Id="AndroidAgentApp.netstandard.dll" Guid="E470B065-2E03-4AAB-A3D8-1714483D4B13">
         <File Id="AndroidAgentApp.netstandard.dll" Source="$(var.AndroidAppAssembliesDir)\netstandard.dll" />
       </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Annotations.dll" Guid="EE7990E2-18C4-416C-A095-914BBCA26F2D">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Annotations.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Annotations.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Compat.dll" Guid="8C4CDC44-2388-4CFA-B724-5D60B01550D2">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Compat.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Compat.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Core.UI.dll" Guid="AD27FF29-1694-4DBB-A256-7E4EE22AE609">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Core.UI.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Core.UI.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Core.Utils.dll" Guid="A36B5AA6-5F4F-4CDC-AE4F-07616772EDF0">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Core.Utils.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Core.Utils.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Fragment.dll" Guid="13AD3B0F-B1D6-4C4B-8B4F-09EAF38A6C91">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Fragment.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Fragment.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Media.Compat.dll" Guid="23D9C948-D5A1-48D0-9DD3-5B2DECD72497">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Media.Compat.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Media.Compat.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.Transition.dll" Guid="3A1763BF-4841-438F-A3D1-C9656232A075">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.Transition.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.Transition.dll" />
+      </Component>
+      <Component Id="AndroidAgentApp.Xamarin.Android.Support.v_.Palette.dll" Guid="1268FB88-26C6-4A29-82C0-1874B9B371C2">
+        <File Id="AndroidAgentApp.Xamarin.Android.Support.v_.Palette.dll" Source="$(var.AndroidAppAssembliesDir)\Xamarin.Android.Support.v7.Palette.dll" />
+      </Component>
     </ComponentGroup>
     <ComponentGroup Id="AndroidAgentAppClientIntegrationComponents" Directory="AndroidAgentAppClientIntegrationInstallFolder">
       <Component Id="Filedf726d8904b8bd646182c5041501fc57a86eb6a4" Guid="CA9D4CC8-8400-4DC7-B9FF-4FEAABA3802A">

--- a/WorkbookApps/Xamarin.Workbooks.Android/Properties/AndroidManifest.xml
+++ b/WorkbookApps/Xamarin.Workbooks.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.workbook_app_android">
-	<uses-sdk android:minSdkVersion="16" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.xamarin.workbook_app_android" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/WorkbookApps/Xamarin.Workbooks.Android/Xamarin.Workbooks.Android.csproj
+++ b/WorkbookApps/Xamarin.Workbooks.Android/Xamarin.Workbooks.Android.csproj
@@ -13,10 +13,10 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AssemblyName>Xamarin.Workbooks.Android</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidSupportedAbis>x86</AndroidSupportedAbis>
     <AndroidLinkMode>None</AndroidLinkMode>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>

--- a/WorkbookApps/Xamarin.Workbooks.Android/Xamarin.Workbooks.Android.csproj
+++ b/WorkbookApps/Xamarin.Workbooks.Android/Xamarin.Workbooks.Android.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.4.0.38779</Version>
+      <Version>2.5.0.121934</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/dependencies.json
+++ b/dependencies.json
@@ -97,7 +97,7 @@
   {
     "Kind": "NuGet",
     "Name": "Xamarin.Forms",
-    "Version": "2.4.0.38779",
+    "Version": "2.5.0.121934",
     "DependentProjects": [
       "Xamarin.Interactive.Forms.Android",
       "Xamarin.Interactive.Forms.iOS",


### PR DESCRIPTION
Bump our enforced Xamarin.Forms version to the latest stable version, and fix inspection of Xamarin.Forms apps.

Read each commit individually for maximum clarity.