### PR TITLE
Mac: Use paths.d to get workbook CLI tool into PATH.

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -310,6 +310,10 @@
     <Exec Command="cp -a &quot;_build\$(Configuration)\WorkbookApps&quot; &quot;$(WorkbooksAppSharedSupportPath)&quot;"/>
     <Copy
       SkipUnchangedFiles="true"
+      SourceFiles="$(MSBuildThisFileDirectory)Package\Mac\workbook"
+      DestinationFolder="$(WorkbooksAppSharedSupportPath)path-bin" />
+    <Copy
+      SkipUnchangedFiles="true"
       SourceFiles="@(AndroidFormsAgentFiles)"
       DestinationFolder="$(WorkbooksAppSharedSupportPath)Agents\Forms\Android"/>
     <Copy

--- a/Clients/Xamarin.Interactive.Client.Mac/AppDelegate.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/AppDelegate.cs
@@ -158,34 +158,32 @@ namespace Xamarin.Interactive.Client.Mac
         static async Task InstallCommandLineToolAsync ()
         {
             try {
-                const string scriptPath = "/usr/local/bin/workbook";
-                var authOpen = await Security.AuthOpen.PreauthorizeAsync (
+                const string pathsDPath = "/etc/paths.d/workbooks";
+                var pathsDAuthOpen = await Security.AuthOpen.PreauthorizeAsync (
                     new XamCore.Security.AuthorizationEnvironment {
                         Prompt = Catalog.Format (Catalog.GetString (
-                            "{0} would like to install a script to " +
+                            "{0} would like to install a path helper to " +
                             "support terminal usage: {1}",
                             comment: "{0} is the app name; {1} is a file path"),
                             ClientInfo.FullProductName,
-                            scriptPath),
+                            pathsDPath),
                         AddToSharedCredentialPool = true
                     },
-                    scriptPath,
-                    mode: 493 /*0755*/);
+                    pathsDPath,
+                    mode: 420 /* 0644 */);
 
-                await authOpen.WriteAsync (h => h.WriteData (NSData.FromString (
-                    "#!/bin/bash\n" +
-                    "\"" + NSBundle.MainBundle.ExecutablePath + "\" cli \"$@\""
+                await pathsDAuthOpen.WriteAsync (h => h.WriteData (NSData.FromString (
+                    Path.Combine (
+                        NSBundle.MainBundle.SharedSupportPath,
+                        "path-bin")
                 )));
 
                 new NSAlert {
                     AlertStyle = NSAlertStyle.Informational,
                     MessageText = Catalog.GetString ("Installation Complete"),
                     InformativeText = Catalog.Format (Catalog.GetString (
-                        "The '{0}' tool has been installed to {1}. " +
-                        "Ensure that {1} is in your PATH.",
-                        comment: "{0} and {1} are both file paths"),
-                        Path.GetFileName (scriptPath),
-                        Path.GetDirectoryName (scriptPath))
+                        "The path helper to support terminal usage has been installed. " +
+                        "Close and reopen your terminal to ensure that PATH updates."))
                 }.RunModal ();
             } catch (Exception e) {
                 e.ToUserPresentable (

--- a/Clients/Xamarin.Interactive.Client/ClientApp.cs
+++ b/Clients/Xamarin.Interactive.Client/ClientApp.cs
@@ -262,7 +262,7 @@ namespace Xamarin.Interactive
             }.Start ();
         }
 
-        static InteractiveInstallationPaths GetWindowsInstallationPaths ()
+        public static InteractiveInstallationPaths GetWindowsInstallationPaths ()
         {
             var frameworkInstallPath = new FilePath (Assembly.GetExecutingAssembly ().Location)
                 .ParentDirectory
@@ -276,7 +276,7 @@ namespace Xamarin.Interactive
                 toolsInstallPath: Path.Combine (frameworkInstallPath, "Tools"));
         }
 
-        static InteractiveInstallationPaths GetMacInstallationPaths ()
+        public static InteractiveInstallationPaths GetMacInstallationPaths ()
         {
             var agentsInstallPath = new FilePath (Assembly.GetExecutingAssembly ().Location)
                 .ParentDirectory

--- a/Clients/Xamarin.Interactive.Client/CommandLineTool/Driver.cs
+++ b/Clients/Xamarin.Interactive.Client/CommandLineTool/Driver.cs
@@ -16,9 +16,14 @@ namespace Xamarin.Interactive.Client.CommandLineTool
     {
         static Driver ()
         {
+            var isMac = Environment.OSVersion.Platform == PlatformID.Unix;
+            var installationPaths = isMac
+                ? ClientApp.GetMacInstallationPaths ()
+                : ClientApp.GetWindowsInstallationPaths ();
             InteractiveInstallation.InitializeDefault (
-                Environment.OSVersion.Platform == PlatformID.Unix,
-                null);
+                isMac,
+                DevEnvironment.RepositoryRootDirectory,
+                installationPaths);
         }
 
         public string [] ClientLaunchUris { get; set; }

--- a/Package/Mac/Scripts/postinstall
+++ b/Package/Mac/Scripts/postinstall
@@ -6,15 +6,16 @@ LEGACY_XS_ADDIN_INSTALL="${DSTROOT}${HOME#/*}/Library/Application Support/Xamari
 rm -rf "$LEGACY_XS_ADDIN_INSTALL/Xamarin.Inspector"
 rm -rf "$LEGACY_XS_ADDIN_INSTALL/Xamarin.Interactive"
 
-CLI_SCRIPT_PATH="${DSTROOT}usr/local/bin/workbook"
-rm -f "$CLI_SCRIPT_PATH"
-mkdir -p "${DSTROOT}usr/local/bin"
+LEGACY_CLI_SCRIPT_PATH="${DSTROOT}usr/local/bin/workbook"
+rm -f "$LEGACY_CLI_SCRIPT_PATH"
+
+PATHS_D_PATH="/etc/paths.d/workbooks"
+rm -f "$PATHS_D_PATH"
+mkdir -p "$(dirname "$PATHS_D_PATH")"
 { cat <<EOF
-#!/bin/bash
-"${DSTROOT}Applications/Xamarin Workbooks.app/Contents/MacOS/Xamarin Workbooks" cli "\$@"
+${DSTROOT}Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin
 EOF
-} > "$CLI_SCRIPT_PATH"
-chmod 0755 "$CLI_SCRIPT_PATH"
+} > "$PATHS_D_PATH"
 
 # before CodeMirror or Monaco we set these to disable all the magic
 # stuff implied by the keys. CodeMirror, etc, handle preventing

--- a/Package/Mac/workbook
+++ b/Package/Mac/workbook
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+bundle_macos_dir="$(cd "$(dirname "$0")/../../MacOS" && pwd)"
+"$bundle_macos_dir/Xamarin Workbooks" cli "$@"


### PR DESCRIPTION
Still generates the wrapper script as part of `postinstall`, but instead of writing it directly into `/usr/local/bin`, it's written into our bundle and that path is added to `/etc/paths.d`.

Fixes #56.