### PR TITLE
Client: Make sure to escape type names for HTML.

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Rendering/Renderers/HtmlRendererBase.cs
+++ b/Clients/Xamarin.Interactive.Client/Rendering/Renderers/HtmlRendererBase.cs
@@ -71,7 +71,10 @@ namespace Xamarin.Interactive.Rendering.Renderers
 
         protected HtmlElement CreateRenderedTypeNameElement (RepresentedType type)
         {
-            return Document.CreateElement ("code", innerHtml: TypeHelper.GetCSharpTypeName (type.Name));
+            using (var writer = new StringWriter ()) {
+                writer.WriteHtmlEscaped (TypeHelper.GetCSharpTypeName (type.Name));
+                return Document.CreateElement ("code", innerHtml: writer.ToString ());
+            }
         }
 
         protected HtmlElement CreateHeaderElement (object obj, string detailsText = null)


### PR DESCRIPTION
Generics get messed up by this--the generic brackets end up creating
a new tag (or multiple tags) for the generic parameters. This affects
generic collections, anonymous types, value tuples, etc., when displayed
in object members mode/enumerable mode.

Fixes #138.