### PR TITLE
Build: Change where ReleaseVersion_SemVerNuGetSafe gets created

### DIFF
--- a/Agents/Xamarin.Interactive/Versioning/ReleaseVersion.cs
+++ b/Agents/Xamarin.Interactive/Versioning/ReleaseVersion.cs
@@ -256,11 +256,14 @@ namespace Xamarin.Versioning
         public override string ToString ()
             => ToSemVerString (true);
 
-        public string ToString (ReleaseVersionFormat format, bool withBuildComponent = false)
+        public string ToString (
+            ReleaseVersionFormat format,
+            bool withBuildComponent = false,
+            bool nugetSafeBuild = false)
         {
             switch (format) {
             case ReleaseVersionFormat.SemVer:
-                return ToSemVerString (withBuildComponent);
+                return ToSemVerString (withBuildComponent, nugetSafeBuild);
             case ReleaseVersionFormat.AppleCFBundleVersion:
                 return ToAppleCFBundleVersion ();
             case ReleaseVersionFormat.AppleCFBundleShortVersion:
@@ -276,7 +279,7 @@ namespace Xamarin.Versioning
             throw new ArgumentOutOfRangeException (nameof (format));
         }
 
-        string ToSemVerString (bool withBuild)
+        string ToSemVerString (bool withBuild, bool nugetSafeBuild = false)
         {
             var builder = new StringBuilder (32);
             builder.AppendFormat (CultureInfo.InvariantCulture, "{0}.{1}.{2}", Major, Minor, Patch);
@@ -307,7 +310,10 @@ namespace Xamarin.Versioning
                 builder.AppendFormat (CultureInfo.InvariantCulture, "{0}", Candidate);
 
             if (Build > 0 && withBuild)
-                builder.AppendFormat (CultureInfo.InvariantCulture, "+{0}", Build);
+                builder.AppendFormat (
+                    CultureInfo.InvariantCulture,
+                    nugetSafeBuild ? "-build.{0}" : "+{0}",
+                    Build);
 
             return builder.ToString ();
         }

--- a/Build/Metadata.targets
+++ b/Build/Metadata.targets
@@ -37,11 +37,6 @@ Copyright 2017 Microsoft. All rights reserved.
         TaskParameter="Value"
         PropertyName="ReleaseVersion_SemVer"/>
     </CreateProperty>
-    <CreateProperty Value="$(PackageDotJson_Version)-build.$(CommonGitInfo_MinMaxCommitDistance)">
-      <Output
-        TaskParameter="Value"
-        PropertyName="ReleaseVersion_SemVerNuGetSafe"/>
-    </CreateProperty>
     <CreateProperty Value="$(CommonGitInfo_MaxRevisionTimestamp)">
       <Output
         TaskParameter="Value"

--- a/Build/Xamarin.Build/MSBuild/ReleaseVersion.cs
+++ b/Build/Xamarin.Build/MSBuild/ReleaseVersion.cs
@@ -16,6 +16,9 @@ namespace Xamarin.MSBuild
         public string SemVer { get; set; }
 
         [Output]
+        public string SemVerNuGetSafe { get; private set; }
+
+        [Output]
         public string SemVerWithoutBuild { get; private set; }
 
         [Output]
@@ -43,7 +46,13 @@ namespace Xamarin.MSBuild
 
             SemVer = semVer.ToString (
                 Versioning.ReleaseVersionFormat.SemVer,
-                withBuildComponent: true);
+                withBuildComponent: true,
+                nugetSafeBuild: false);
+
+            SemVerNuGetSafe = semVer.ToString (
+                Versioning.ReleaseVersionFormat.SemVer,
+                withBuildComponent: true,
+                nugetSafeBuild: true);
 
             SemVerWithoutBuild = semVer.ToString (
                 Versioning.ReleaseVersionFormat.SemVer,

--- a/Build/Xamarin.Build/Xamarin.Build.targets
+++ b/Build/Xamarin.Build/Xamarin.Build.targets
@@ -51,6 +51,9 @@ Copyright 2017 Microsoft. All rights reserved.
         TaskParameter="SemVer"
         PropertyName="ReleaseVersion_SemVer"/>
       <Output
+        TaskParameter="SemVerNuGetSafe"
+        PropertyName="ReleaseVersion_SemVerNuGetSafe"/>
+      <Output
         TaskParameter="SemVerWithoutBuild"
         PropertyName="ReleaseVersion_SemVerWithoutBuild"/>
       <Output
@@ -70,6 +73,7 @@ Copyright 2017 Microsoft. All rights reserved.
         PropertyName="ReleaseVersion_FriendlyShort"/>
     </ReleaseVersion>
     <Message Text="SemVer: $(ReleaseVersion_SemVer)" Importance="high"/>
+    <Message Text="SemVerNuGetSafe: $(ReleaseVersion_SemVerNuGetSafe)" Importance="high"/>
     <Message Text="SemVerWithoutBuild: $(ReleaseVersion_SemVerWithoutBuild)" Importance="high"/>
     <Message Text="AppleCFBundleVersion: $(ReleaseVersion_AppleCFBundleVersion)" Importance="high"/>
     <Message Text="AppleCFBundleShortVersion: $(ReleaseVersion_AppleCFBundleShortVersion)" Importance="high"/>

--- a/Tests/Xamarin.Interactive.Tests/ReleaseVersionTests.cs
+++ b/Tests/Xamarin.Interactive.Tests/ReleaseVersionTests.cs
@@ -80,6 +80,17 @@ namespace Xamarin.Interactive.Tests
                 .ToString (ReleaseVersionFormat.FriendlyShort, withBuildComponent)
                 .ShouldEqual (expectedFriendly);
 
+        [TestCase ("1.2.0", "1.2.0")]
+        [TestCase ("1.2.0+8", "1.2.0-build.8")]
+        [TestCase ("1.4.0-alpha1+3", "1.4.0-alpha1-build.3")]
+        [TestCase ("1.4.0-rc4", "1.4.0-rc4")]
+        [TestCase ("1.4.3-rc4+938", "1.4.3-rc4-build.938")]
+        public void NuGetSafe (string semVer, string expectedNuGetSafe)
+            => ReleaseVersion
+                .Parse (semVer)
+                .ToString (ReleaseVersionFormat.SemVer, true, true)
+                .ShouldEqual (expectedNuGetSafe);
+
         [TestCase ("1.4.0-alpha1", "1.4a1")]
         [TestCase ("1.4.1-alpha2", "1.4.1a2")]
         [TestCase ("1.4.2-alpha3", "1.4.2a3")]


### PR DESCRIPTION
Previously this was created in `Metadata.targets` along with
`ReleaseVersion_SemVer`, but I failed to realize that this property was
meant to be consumed and then overwritten later in
`Xamarin.Build.targets`.

Moved `ReleaseVersion_SemVerNuGetSafe` to be generated there as well so
it can benefit from `ReleaseVersion` logic that excludes build numbers
when they are not needed. And also because it always should have been
there.