### PR TITLE
Only submit the app.sessionStart telemetry object

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Preferences/Prefs.cs
+++ b/Clients/Xamarin.Interactive.Client/Preferences/Prefs.cs
@@ -73,9 +73,6 @@ namespace Xamarin.Interactive.Preferences
 
         public static class Telemetry
         {
-            public static readonly Preference<string> UserGuid
-                = new Preference<string> ("telemetry.userGuid", Guid.NewGuid ().ToString ());
-
             public static readonly Preference<bool> Enabled
                 = new Preference<bool> ("telemetry.enabled", true);
         }

--- a/Clients/Xamarin.Interactive.Client/Telemetry/Client.cs
+++ b/Clients/Xamarin.Interactive.Client/Telemetry/Client.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 
 using Xamarin.Interactive.Logging;
 using Xamarin.Interactive.Preferences;
+using Xamarin.Interactive.Telemetry.Events;
 
 namespace Xamarin.Interactive.Telemetry
 {
@@ -93,6 +94,9 @@ namespace Xamarin.Interactive.Telemetry
             if (httpClient == null || !enabled)
                 return;
 
+            if (!(evnt is AppSessionStart))
+                return;
+
             PostEventAsync (evnt).Forget ();
         }
 
@@ -126,7 +130,7 @@ namespace Xamarin.Interactive.Telemetry
             }
 
             var response = await httpClient.PostAsync (
-                "addlog",
+                "logEvent",
                 new EventObjectStreamContent (this, evnt));
 
             if (response.StatusCode == HttpStatusCode.Forbidden) {

--- a/Clients/Xamarin.Interactive.Client/Telemetry/Events/AppSessionStart.cs
+++ b/Clients/Xamarin.Interactive.Client/Telemetry/Events/AppSessionStart.cs
@@ -19,16 +19,11 @@ namespace Xamarin.Interactive.Telemetry.Events
     {
         const string TAG = nameof (AppSessionStart);
 
-        readonly string userId;
-
         public AppSessionStart () : base ("app.sessionStart")
         {
             MainThread.Ensure ();
 
-            // explicitly get and set in the case where it was not persisted
-            // and so we were returned the default Guid.NewGuid. save it.
-            userId = Prefs.Telemetry.UserGuid.GetValue ();
-            Prefs.Telemetry.UserGuid.SetValue (userId);
+            PreferenceStore.Default.Remove ("telemetry.userGuid");
 
             // force this object to init on the main thread so that we can read
             // the update channel preference
@@ -39,9 +34,6 @@ namespace Xamarin.Interactive.Telemetry.Events
         {
             var stopwatch = new Stopwatch ();
             stopwatch.Start ();
-
-            writer.WritePropertyName ("userId");
-            writer.WriteValue (userId);
 
             writer.WritePropertyName ("app");
             Objects.Application.Instance.Serialize (writer);


### PR DESCRIPTION
Disassociate it from the anonymous persistent user GUID and expunge it from the preference store.