### PR TITLE
Client/Mac: Fix opening workbooks from console driver & recent menu

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/AppDelegate.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/AppDelegate.cs
@@ -196,7 +196,7 @@ namespace Xamarin.Interactive.Client.Mac
         {
             SessionDocumentController
                 .SharedDocumentController
-                .OpenDocument (new NSUrl (filename));
+                .OpenDocument (NSUrl.FromFilename (filename));
             return true;
         }
 

--- a/Clients/Xamarin.Interactive.Client/Client/ClientSession.cs
+++ b/Clients/Xamarin.Interactive.Client/Client/ClientSession.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Interactive.Client
             ResetAgentConnection ();
             cancellationTokenSource.Cancel ();
             observable.Observers.OnCompleted ();
-            WorkbookPageViewModel.Dispose ();
+            WorkbookPageViewModel?.Dispose ();
         }
 
         public void InitializeViewControllers (IClientSessionViewControllers viewControllers)

--- a/Tests/Workbooks/Regression/Weird %25 Name.workbook
+++ b/Tests/Workbooks/Regression/Weird %25 Name.workbook
@@ -1,0 +1,11 @@
+---
+uti: com.xamarin.workbook
+id: f7bb14cb-0a9e-4d8f-a08f-280f587d7842
+title: Weird %25 Name
+platforms:
+- Console
+---
+
+```csharp
+Console.WriteLine("Hello, I have a weird name!");
+```

--- a/Tests/Workbooks/Regression/Weird %Name.workbook
+++ b/Tests/Workbooks/Regression/Weird %Name.workbook
@@ -1,0 +1,11 @@
+---
+uti: com.xamarin.workbook
+id: f7bb14cb-0a9e-4d8f-a08f-280f587d7842
+title: Weird %Name
+platforms:
+- Console
+---
+
+```csharp
+Console.WriteLine("Hello, I have a weird name!");
+```


### PR DESCRIPTION
The console driver was broken because the previous fix was incomplete—it only worked when you were in a built checkout of the repository. The new fix correctly takes advantage of the fact that the console driver _is_ the application, and uses its own location to look up the right thing to launch.

The recent menu on macOS was broken for files with spaces in the name—we were using the wrong NSUrl constructor. Using the right one does the correct thing without any additional hacking around. Added some workbooks with odd names (%-encoded, in particular) to make sure that we can open things that turn into weird URLs.