### PR TITLE
Make sure the previous projection is valid before computing the rotation

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Camera/Dolly.cs
+++ b/Clients/Xamarin.Interactive.Client/Camera/Dolly.cs
@@ -97,6 +97,12 @@ namespace Xamarin.Interactive.Camera
         public void DragRotate (TPoint p, float width, float height)
         {
             var direction = ProjectToSphere (previousLocation = Convert (p), width, height);
+            
+            // if we get here before previousDirection is initialized
+            // initalize it and fall out in the delta check
+            if (previousDirection.LengthSquared () == 0.0)
+                previousDirection = direction;
+
             if ((direction - previousDirection).LengthSquared () < 0.001)
                 return;
 


### PR DESCRIPTION
Avoid potential problem if a motion event is delivered before the first press event
in wpf by ensuring the the previous projection is valid.

Fixes #86 