### PR TITLE
Don't attempt to render empty views

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Windows/ViewModels/InspectTreeNode3D.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/ViewModels/InspectTreeNode3D.cs
@@ -96,6 +96,9 @@ namespace Xamarin.Interactive.Client.Windows.ViewModels
                 };
             }
 
+            if (view.Width <= 0 || view.Height <= 0)
+                return;
+
             var size = new Size (view.Width, view.Height);
             var visual = new DrawingVisual ();
             using (var context = visual.RenderOpen ()) {

--- a/Clients/Xamarin.Interactive.Client.Windows/Views/InspectTreeView.xaml.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/InspectTreeView.xaml.cs
@@ -220,7 +220,7 @@ namespace Xamarin.Interactive.Client.Windows.Views
             if (Tree?.SelectedNode == null)
                 SelectedNode = null;
 
-            selectedNode = representedNode.TraverseTree (c => c.Children.OfType<InspectTreeNode3D> ())
+            selectedNode = representedNode?.TraverseTree (c => c.Children.OfType<InspectTreeNode3D> ())
                 .FirstOrDefault (node3D => node3D.Node == Tree?.SelectedNode);
         }
 


### PR DESCRIPTION
In certain cases android views that are in the visual tree but outside of the visible region can retain negative values. Make the wpf 3d view slightly more robust by handing this case without an exception