### PR TITLE
Build.proj: prefer $(MSBuildThisFileDirectory)nuget.exe

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -28,6 +28,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <Npm Condition="'$(Npm)' == ''">npm</Npm>
+    <NuGet Condition="'$(NuGet)' == '' And Exists('$(MSBuildThisFileDirectory)nuget.exe')">$(MSBuildThisFileDirectory)nuget.exe</NuGet>
     <NuGet Condition="'$(NuGet)' == '' And Exists('$(Provisionator_ArtifactCachePath)nuget.exe')">$(Provisionator_ArtifactCachePath)nuget.exe</NuGet>
   </PropertyGroup>
 


### PR DESCRIPTION
For now, makes it easier to run `/t:Package` without having access to provisionator. We should probably make this more automatic/magic/whatever in a second pass.