### PR TITLE
Update Postinstall to stop confusion

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/PackageAssets/Scripts/postinstall
+++ b/Clients/Xamarin.Interactive.Client.Mac/PackageAssets/Scripts/postinstall
@@ -8,15 +8,13 @@ rm -rf "$LEGACY_XS_ADDIN_INSTALL/Xamarin.Interactive"
 
 LEGACY_CLI_SCRIPT_PATH="${DSTROOT}usr/local/bin/workbook"
 rm -f "$LEGACY_CLI_SCRIPT_PATH"
-
-PATHS_D_PATH="/etc/paths.d/workbooks"
-rm -f "$PATHS_D_PATH"
-mkdir -p "$(dirname "$PATHS_D_PATH")"
-{ cat <<EOF
-${DSTROOT}Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin
-EOF
-} > "$PATHS_D_PATH"
-
+if [ -f ~/.zshrc ]; then
+    echo -n "\nexport PATH="${DSTROOT}Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin" >> ~/.zshrc
+elif [ -f ~/.profile ]; then
+        echo -n "\nexport PATH="${DSTROOT}Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin" >> ~/.profile
+else; then
+        echo 'Cannot find a shell initialization file! Please add this line to startup script in order to setup the path for Xamarin Workbooks: export PATH="${DSTROOT}Applications/Xamarin Workbooks.app/Contents/SharedSupport/path-bin'
+fi
 # before CodeMirror or Monaco we set these to disable all the magic
 # stuff implied by the keys. CodeMirror, etc, handle preventing
 # undesirable magic edits directly. Therefore, delete these keys


### PR DESCRIPTION
Some people have not been able to find where the path is being added ([Here's One](https://stackoverflow.com/questions/48840425/cant-remove-an-item-in-path-xamarin-workbooks/49483798)).  Adding the path to a standard initialization script allows for more transparency overall.

I am unable to test this, so let me know what you think!