### PR TITLE
Serialization: use full type names everywhere

### DIFF
--- a/Agents/Xamarin.Interactive/Serialization/InteractiveJsonSerializerSettings.cs
+++ b/Agents/Xamarin.Interactive/Serialization/InteractiveJsonSerializerSettings.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Interactive.Serialization
 
         #if !EXTERNAL_INTERACTIVE_JSON_SERIALIZER_SETTINGS
         public static InteractiveJsonSerializerSettings SharedInstance { get; }
-            = new InteractiveJsonSerializerSettings (true);
+            = new InteractiveJsonSerializerSettings ();
         #endif
 
         sealed class InteractiveJsonContractResolver : DefaultContractResolver
@@ -88,21 +88,14 @@ namespace Xamarin.Interactive.Serialization
 
         sealed class InteractiveJsonBinder : ISerializationBinder
         {
-            readonly bool bindUsingTypeFullName;
-
-            public InteractiveJsonBinder (bool bindUsingTypeFullName)
-                => this.bindUsingTypeFullName = bindUsingTypeFullName;
-
             public void BindToName (Type serializedType, out string assemblyName, out string typeName)
             {
                 assemblyName = null;
 
                 if (typeof (InspectView).IsAssignableFrom (serializedType))
                     typeName = typeof (InspectView).ToSerializableName ();
-                else if (bindUsingTypeFullName)
-                    typeName = serializedType.FullName;
                 else
-                    typeName = serializedType.Name;
+                    typeName = serializedType.FullName;
             }
 
             public Type BindToType (string assemblyName, string typeName)
@@ -115,10 +108,10 @@ namespace Xamarin.Interactive.Serialization
         #else
         InteractiveJsonSerializerSettings
         #endif
-        (bool bindUsingTypeFullName = false)
+        ()
         {
             ContractResolver = new InteractiveJsonContractResolver ();
-            SerializationBinder = new InteractiveJsonBinder (bindUsingTypeFullName);
+            SerializationBinder = new InteractiveJsonBinder ();
 
             // Non-default NJS Converters
             Converters.Add (new MonacoAwareStringEnumConverter ());

--- a/Clients/Xamarin.Interactive.Client.Web/ClientApp/evaluation.ts
+++ b/Clients/Xamarin.Interactive.Client.Web/ClientApp/evaluation.ts
@@ -30,10 +30,10 @@ export interface Diagnostic {
 // Events
 
 export const enum CodeCellEventType {
-    EvaluationStarted = 'CodeCellEvaluationStartedEvent',
-    EvaluationFinished = 'CodeCellEvaluationFinishedEvent',
-    Evaluation = 'Evaluation',
-    CapturedOutputSegment = 'CapturedOutputSegment'
+    EvaluationStarted = 'Xamarin.Interactive.CodeAnalysis.Events.CodeCellEvaluationStartedEvent',
+    EvaluationFinished = 'Xamarin.Interactive.CodeAnalysis.Events.CodeCellEvaluationFinishedEvent',
+    Evaluation = 'Xamarin.Interactive.CodeAnalysis.Evaluating.Evaluation',
+    CapturedOutputSegment = 'Xamarin.Interactive.CodeAnalysis.CapturedOutputSegment'
 }
 
 export interface ICodeCellEvent {

--- a/Clients/Xamarin.Interactive.Client.Web/ClientApp/renderers/ImageRenderer.tsx
+++ b/Clients/Xamarin.Interactive.Client.Web/ClientApp/renderers/ImageRenderer.tsx
@@ -21,7 +21,7 @@ import {
 
 import './ImageRenderer.scss'
 
-const RepresentationName = 'Image'
+const RepresentationName = 'Xamarin.Interactive.Representations.Image'
 
 export default function ImageRendererFactory(result: CodeCellResult) {
     return getFirstRepresentationOfType(result, RepresentationName)
@@ -33,7 +33,7 @@ interface ImageData {
     $type: string
     format: string
     data: {
-        $type: 'Byte[]'
+        $type: 'System.Byte[]'
         $value: string
     }
     width: number

--- a/Clients/Xamarin.Interactive.Client.Web/ClientApp/renderers/ToStringRenderer.tsx
+++ b/Clients/Xamarin.Interactive.Client.Web/ClientApp/renderers/ToStringRenderer.tsx
@@ -13,13 +13,7 @@ import {
     getFirstRepresentationOfType
 } from '../rendering'
 
-const RepresentationName = 'ToStringRepresentation'
-
-export default function ToStringRendererFactory(result: CodeCellResult) {
-    return getFirstRepresentationOfType(result, RepresentationName)
-        ? new ToStringRenderer
-        : null
-}
+export const ToStringRepresentationDataTypeName = 'Xamarin.Interactive.Representations.ToStringRepresentation'
 
 export interface ToStringRepresentationData {
     $type: string
@@ -29,10 +23,18 @@ export interface ToStringRepresentationData {
     }[]
 }
 
+export default function ToStringRendererFactory(result: CodeCellResult) {
+    return getFirstRepresentationOfType(result, ToStringRepresentationDataTypeName)
+        ? new ToStringRenderer
+        : null
+}
+
 class ToStringRenderer implements ResultRenderer {
     getRepresentations(result: CodeCellResult) {
         const reps: ResultRendererRepresentation[] = []
-        const value = getFirstRepresentationOfType<ToStringRepresentationData>(result, RepresentationName)
+        const value = getFirstRepresentationOfType<ToStringRepresentationData>(
+            result,
+            ToStringRepresentationDataTypeName)
 
         if (value) {
             // TODO: some way to toggle between current culture (what we're using now,

--- a/Clients/Xamarin.Interactive.Client.Web/ClientApp/renderers/VerbatimHtmlRenderer.tsx
+++ b/Clients/Xamarin.Interactive.Client.Web/ClientApp/renderers/VerbatimHtmlRenderer.tsx
@@ -13,12 +13,15 @@ import {
     ResultRendererRepresentation,
     getFirstRepresentationOfType
 } from '../rendering'
-import { ToStringRepresentationData } from './ToStringRenderer'
+import {
+    ToStringRepresentationDataTypeName,
+    ToStringRepresentationData
+ } from './ToStringRenderer'
 
-const xirType = 'Xamarin.Interactive.Representations.VerbatimHtml'
+const RepresentationTypeName = 'Xamarin.Interactive.Representations.VerbatimHtml'
 
 export default function VerbatimHtmlRendererFactory(result: CodeCellResult) {
-    return getFirstRepresentationOfType(result, 'VerbatimHtml')
+    return getFirstRepresentationOfType(result, RepresentationTypeName)
         ? new VerbatimHtmlRenderer
         : null
 }
@@ -30,7 +33,10 @@ class VerbatimHtmlRenderer implements ResultRenderer {
         // avoids sending duplicate data across the wire.
         //
         // So, grab the ToStringRepresentation and render that as HTML instead.
-        const rep = getFirstRepresentationOfType<ToStringRepresentationData>(result, 'ToStringRepresentation')
+        const rep = getFirstRepresentationOfType<ToStringRepresentationData>(
+            result,
+            ToStringRepresentationDataTypeName)
+
         if (rep)
             return [{
                 displayName: 'HTML',


### PR DESCRIPTION
Short type names are problematic if we ever need to go back to .NET from TypeScript. We don't have too many type name checks on the TS side so just suck it up and check full type names.