### PR TITLE
Fix fresh build to work with Mono 5.10

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -179,8 +179,10 @@
     Name="Restore"
     DependsOnTargets="@(ProfileTargets)">
     <Message Importance="High" Text="Restoring NuGet packages for $(SolutionFileRelative)..."/>
+    <!-- See https://github.com/Microsoft/msbuild/issues/2455 -->
     <MSBuild
       Projects="$(SolutionFile)"
+      Properties="_TrickyTricky=SoWeDontNeedRestoreFlag"
       Targets="Restore"/>
   </Target>
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,7 +2,7 @@
   {
     "Kind": "GitRepo",
     "Name": "https://github.com/xamarin/workbooks-proprietary",
-    "Version": "master",
+    "Version": "bumpy",
     "Path": "workbooks-proprietary"
   },
   {


### PR DESCRIPTION
Running `Restore` and `Build` targets together requires a workaround to
continue to work as we've been wanting it to work.

Alternatively, we could start running `msbuild /restore` to run a full
build with a separate restore operation happening beforehand.

See https://github.com/Microsoft/msbuild/issues/2455 for details.