### PR TITLE
Build: Remove some Android assemblies that shouldn't be shipped.

### DIFF
--- a/WorkbookApps/WorkbookApp.targets
+++ b/WorkbookApps/WorkbookApp.targets
@@ -14,6 +14,9 @@
 
   <ItemGroup>
     <BundleFxAssemblies Include="$(MonoFrameworkPath)/*.dll" />
+    <BundleFxAssemblies Remove="$(MonoFrameworkPath)/Java.Interop.Tools.*.dll" />
+    <BundleFxAssemblies Remove="$(MonoFrameworkPath)/Xamarin.Android.Cecil*.dll" />
+    <BundleFxAssemblies Remove="$(MonoFrameworkPath)/Xamarin.Android.Tools.*.dll" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
X.A started shipping these into the framework reference assembly directory on Windows
at some point (they started showing up in our Appveyor builds randomly) and they 
shouldn't be shipped--they're used during the build process to build an APK, but aren't
expected to be used by anyone writing Xamarin.Android apps.