### PR TITLE
Build: Remove some Android assemblies that shouldn't be shipped.

### DIFF
--- a/WorkbookApps/WorkbookApp.targets
+++ b/WorkbookApps/WorkbookApp.targets
@@ -14,6 +14,9 @@
   
   <ItemGroup>
     <BundleFxAssemblies Include="$(MonoFrameworkPath)/*.dll" />
+    <BundleFxAssemblies Remove="$(MonoFrameworkPath)/Java.Interop.Tools.*.dll" />
+    <BundleFxAssemblies Remove="$(MonoFrameworkPath)/Xamarin.Android.Cecil*.dll" />
+    <BundleFxAssemblies Remove="$(MonoFrameworkPath)/Xamarin.Android.Tools.*.dll" />
   </ItemGroup>
   
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ cache:
 build_script:
 - cmd: msbuild Build.proj /p:Configuration=Release /t:UpdateBuildInfo,Build,Package
 test_script:
-- cmd: msbuild Build.proj /t:TestRegressions /p:Configuration=Release
+- cmd: msbuild Build.proj /t:Test /p:Configuration=Release
 artifacts:
 - path: _artifacts\*.msi
   name: Installer


### PR DESCRIPTION
X.A started shipping these at some point (they started showing up in our
Appveyor builds randomly) and they shouldn't be shipped--they're used during the
build process to build an APK, but aren't expected to be used by anyone writing
Xamarin.Android apps.

Backport of https://github.com/Microsoft/workbooks/pull/304.