### PR TITLE
 Bump Xamarin.Forms to 3.0.0.482510

### DIFF
--- a/Agents/Xamarin.Interactive.Forms.Android/Xamarin.Interactive.Forms.Android.csproj
+++ b/Agents/Xamarin.Interactive.Forms.Android/Xamarin.Interactive.Forms.Android.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.5.0.121934</Version>
+      <Version>3.0.0.482510</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Agents/Xamarin.Interactive.Forms.iOS/Xamarin.Interactive.Forms.iOS.csproj
+++ b/Agents/Xamarin.Interactive.Forms.iOS/Xamarin.Interactive.Forms.iOS.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.5.0.121934</Version>
+      <Version>3.0.0.482510</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Agents/Xamarin.Interactive.Forms/Xamarin.Interactive.Forms.csproj
+++ b/Agents/Xamarin.Interactive.Forms/Xamarin.Interactive.Forms.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="2.5.0.121934" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/CodeAnalysis/WorkspaceConfiguration.cs
+++ b/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/CodeAnalysis/WorkspaceConfiguration.cs
@@ -204,30 +204,6 @@ namespace Xamarin.Interactive.CodeAnalysis
                 return;
 
             var deps = dependencyResolver.Resolve (new [] { new FilePath (formsAssembly) });
-
-            // Now dig out the resolved assembly that is Xamarin.Forms.Core, and compare it to the
-            // default ref.
-            var resolvedFormsAssembly = deps.FirstOrDefault (d => d.AssemblyName.Name == "Xamarin.Forms.Core");
-            if (resolvedFormsAssembly == null) {
-                Log.Warning (TAG,
-                    "Cannot enable Forms integration because Forms cannot be " +
-                    "resolved. Check log for assembly search path issues.");
-                return;
-            }
-            var ourVersion = resolvedFormsAssembly.AssemblyName.Version;
-            var theirVersion = formsVersion;
-
-            if (ourVersion.Major != theirVersion.Major) {
-                Log.Warning (
-                    TAG,
-                    "Assembly version mismatch between app's Xamarin.Forms.Core and" +
-                    $"our referenced Xamarin.Forms.Core. Our version: {ourVersion}, " +
-                    $"their version: {theirVersion}. Won't load Xamarin.Forms agent " +
-                    "integration, as it probably won't work."
-                );
-                return;
-            }
-
             var includePeImage = configuration.IncludePEImagesInDependencyResolution;
             var assembliesToLoad = deps.Select (dep => {
                 var peImage = includePeImage ? GetFileBytes (dep.Path) : null;

--- a/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/NuGet/InteractivePackageManager.cs
+++ b/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/NuGet/InteractivePackageManager.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Interactive.NuGet
         internal const string IntegrationPackageId = "Xamarin.Workbooks.Integration";
 
         internal static readonly InteractivePackageDescription FixedXamarinFormsPackageDescription
-            = new InteractivePackageDescription ("Xamarin.Forms", "2.5.0.121934");
+            = new InteractivePackageDescription ("Xamarin.Forms", "3.0.0.482510");
 
         internal static readonly PackageIdentity FixedXamarinFormsPackageIdentity
             = FixedXamarinFormsPackageDescription.ToPackageIdentity ();

--- a/Package/Windows/AndroidAgentAppAssemblies.wxs
+++ b/Package/Windows/AndroidAgentAppAssemblies.wxs
@@ -611,20 +611,11 @@
       <Component Id="AndroidAgentApp.System.Collections.dll" Guid="EBF7F64E-5D71-4C1E-8B42-D8D1373DA72C">
         <File Id="AndroidAgentApp.System.Collections.dll" Source="$(var.AndroidAppAssembliesDir)\System.Collections.dll" />
       </Component>
-      <Component Id="AndroidAgentApp.System.ComponentModel.dll" Guid="15EF00B0-202F-4F32-B319-8802264B0085">
-        <File Id="AndroidAgentApp.System.ComponentModel.dll" Source="$(var.AndroidAppAssembliesDir)\System.ComponentModel.dll" />
-      </Component>
       <Component Id="AndroidAgentApp.System.Diagnostics.Debug.dll" Guid="17EF15CA-6880-4836-9246-20284E820865">
         <File Id="AndroidAgentApp.System.Diagnostics.Debug.dll" Source="$(var.AndroidAppAssembliesDir)\System.Diagnostics.Debug.dll" />
       </Component>
       <Component Id="AndroidAgentApp.System.Dynamic.Runtime.dll" Guid="5D36D55C-E583-419C-86CD-E59E154781F9">
         <File Id="AndroidAgentApp.System.Dynamic.Runtime.dll" Source="$(var.AndroidAppAssembliesDir)\System.Dynamic.Runtime.dll" />
-      </Component>
-      <Component Id="AndroidAgentApp.System.Globalization.dll" Guid="4ED9E8DD-0297-4675-A452-8F99C085FDDA">
-        <File Id="AndroidAgentApp.System.Globalization.dll" Source="$(var.AndroidAppAssembliesDir)\System.Globalization.dll" />
-      </Component>
-      <Component Id="AndroidAgentApp.System.IO.dll" Guid="43A925B4-5B2F-48AC-BFFC-50418E7C2FF9">
-        <File Id="AndroidAgentApp.System.IO.dll" Source="$(var.AndroidAppAssembliesDir)\System.IO.dll" />
       </Component>
       <Component Id="AndroidAgentApp.System.Linq.Expressions.dll" Guid="A8735D36-6204-47AF-8D65-6EA0778B60AF">
         <File Id="AndroidAgentApp.System.Linq.Expressions.dll" Source="$(var.AndroidAppAssembliesDir)\System.Linq.Expressions.dll" />
@@ -650,17 +641,8 @@
       <Component Id="AndroidAgentApp.System.Runtime.dll" Guid="CEC36B65-C22C-463B-BF82-83D4EF94C9B2">
         <File Id="AndroidAgentApp.System.Runtime.dll" Source="$(var.AndroidAppAssembliesDir)\System.Runtime.dll" />
       </Component>
-      <Component Id="AndroidAgentApp.System.Text.RegularExpressions.dll" Guid="203AD343-E0BA-4C88-A704-8902B18AF115">
-        <File Id="AndroidAgentApp.System.Text.RegularExpressions.dll" Source="$(var.AndroidAppAssembliesDir)\System.Text.RegularExpressions.dll" />
-      </Component>
-      <Component Id="AndroidAgentApp.System.Threading.Tasks.dll" Guid="1CF6A7BE-2732-4432-A0AB-5DA8D74CD07C">
-        <File Id="AndroidAgentApp.System.Threading.Tasks.dll" Source="$(var.AndroidAppAssembliesDir)\System.Threading.Tasks.dll" />
-      </Component>
       <Component Id="AndroidAgentApp.System.Threading.dll" Guid="29E7A20B-0139-4650-B18A-6ECDEBA5234A">
         <File Id="AndroidAgentApp.System.Threading.dll" Source="$(var.AndroidAppAssembliesDir)\System.Threading.dll" />
-      </Component>
-      <Component Id="AndroidAgentApp.System.Xml.ReaderWriter.dll" Guid="3EAAD511-5DA5-4C80-8807-6718F28D76B1">
-        <File Id="AndroidAgentApp.System.Xml.ReaderWriter.dll" Source="$(var.AndroidAppAssembliesDir)\System.Xml.ReaderWriter.dll" />
       </Component>
       <Component Id="AndroidAgentApp.System.Diagnostics.StackTrace.dll" Guid="6EE8BBCE-8BBF-4C02-9E38-55AA5182FA25">
         <File Id="AndroidAgentApp.System.Diagnostics.StackTrace.dll" Source="$(var.AndroidAppAssembliesDir)\System.Diagnostics.StackTrace.dll" />

--- a/WorkbookApps/Xamarin.Workbooks.Android/Xamarin.Workbooks.Android.csproj
+++ b/WorkbookApps/Xamarin.Workbooks.Android/Xamarin.Workbooks.Android.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>2.5.0.121934</Version>
+      <Version>3.0.0.482510</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/dependencies.json
+++ b/dependencies.json
@@ -181,7 +181,7 @@
   {
     "Kind": "NuGet",
     "Name": "Xamarin.Forms",
-    "Version": "2.5.0.121934",
+    "Version": "3.0.0.482510",
     "DependentProjects": [
       "Xamarin.Interactive.Forms.Android",
       "Xamarin.Interactive.Forms.iOS",


### PR DESCRIPTION
During testing, we found some issues with XF integration and iOS, but these problems exist on 1.4.0, and are not regressions caused by this upgrade.