### PR TITLE
 Fix potential hangs loading iOS workbooks

### DIFF
--- a/Agents/Xamarin.Interactive/InteractiveInstallation.cs
+++ b/Agents/Xamarin.Interactive/InteractiveInstallation.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Interactive
                 searchPaths.Add (Path.Combine (
                     BuildPath, "Clients", "Xamarin.Interactive.Client.Mac.SimChecker"));
 
-            simCheckerExecutablePaths = LocateFiles (searchPaths, "Xamarin.Interactive.Mac.SimChecker.exe").ToList ();
+            simCheckerExecutablePaths = LocateFiles (searchPaths, "Xamarin.Interactive.Client.Mac.SimChecker.exe").ToList ();
             return simCheckerExecutablePaths;
         }
 

--- a/ClientIntegrations/Xamarin.Workbooks.Client.iOS/iOSAgentProcess.cs
+++ b/ClientIntegrations/Xamarin.Workbooks.Client.iOS/iOSAgentProcess.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -166,7 +167,7 @@ namespace Xamarin.Interactive.Client.AgentProcesses
             }
 
             var localSimChecker = InteractiveInstallation.Default.LocateSimChecker ();
-            var simCheckerPath = $"{macTempPath}/Xamarin.Interactive.Mac.SimChecker.exe";
+            var simCheckerPath = $"{macTempPath}/{Path.GetFileName (localSimChecker)}";
 
             // This file is really small, so copying it fresh every time is OK.
             try {

--- a/Clients/Xamarin.Interactive.Client.Mac.SimChecker/Program.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac.SimChecker/Program.cs
@@ -9,14 +9,16 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
+using Xamarin.Interactive.Logging;
 using Xamarin.Interactive.MTouch;
 
 namespace Xamarin.Interactive.Mac.SimChecker
 {
     public class Program
     {
-        public static void Main (string[] args)
+        public static async Task Main (string[] args)
         {
             if (args.Length == 1 && args [0] == "--version") {
                 Console.WriteLine (BuildInfo.VersionString);
@@ -24,9 +26,11 @@ namespace Xamarin.Interactive.Mac.SimChecker
                 return;
             }
 
+            Log.Initialize (new LogProvider (LogLevel.Debug));
+
             string sdkRoot;
             try {
-                sdkRoot = MTouchSdkTool.GetXcodeSdkRoot ();
+                sdkRoot = await MTouchSdkTool.GetXcodeSdkRootAsync ();
             } catch (Exception e) {
                 Console.Error.WriteLine (e.Message);
                 Environment.Exit (100); // Xcode not configured in XS or not installed at /Applications/Xcode.app
@@ -41,7 +45,7 @@ namespace Xamarin.Interactive.Mac.SimChecker
 
             MTouchListSimXml mtouchList;
             try {
-                mtouchList = MTouchSdkTool.MtouchListSimAsync (sdkRoot).Result;
+                mtouchList = await MTouchSdkTool.MtouchListSimAsync (sdkRoot);
             } catch (Exception e) {
                 e = (e as AggregateException)?.InnerExceptions?.FirstOrDefault () ?? e;
                 Console.Error.WriteLine (e.Message);

--- a/Clients/Xamarin.Interactive.Client.Mac.SimChecker/Xamarin.Interactive.Client.Mac.SimChecker.csproj
+++ b/Clients/Xamarin.Interactive.Client.Mac.SimChecker/Xamarin.Interactive.Client.Mac.SimChecker.csproj
@@ -1,52 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D495E2AE-BF3E-444B-B3D6-91EF14293831}</ProjectGuid>
+    <TargetFramework>net461</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Xamarin.Interactive.Mac.SimChecker</RootNamespace>
-    <AssemblyName>Xamarin.Interactive.Mac.SimChecker</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ProductVersion>8.0.30703</ProductVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;CATALOG_API_ONLY</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ExternalConsole>true</ExternalConsole>
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
     <DefineConstants>CATALOG_API_ONLY</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ExternalConsole>true</ExternalConsole>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Xml.Serialization" />
-    <Reference Include="System.Xml" />
+    <Compile Include="..\..\Agents\Xamarin.Interactive\BuildInfo.cs" />
+    <Compile Include="..\..\Agents\Xamarin.Interactive\Collections\PropertyList.cs" />
+    <Compile Include="..\..\Agents\Xamarin.Interactive\I18N\Catalog.cs" />
+    <Compile Include="..\..\Agents\Xamarin.Interactive\Versioning\ReleaseVersion.cs" />
+    <Compile Include="..\..\Agents\Xamarin.Interactive\Logging\**\*.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="..\..\Agents\Xamarin.Interactive\BuildInfo.cs">
-      <Link>BuildInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Agents\Xamarin.Interactive\I18N\Catalog.cs">
-      <Link>Catalog.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Agents\Xamarin.Interactive\Versioning\ReleaseVersion.cs">
-      <Link>ReleaseVersion.cs</Link>
-    </Compile>
-  </ItemGroup>
+
   <Import Project="..\Xamarin.Interactive.MTouch\Xamarin.Interactive.MTouch.projitems" Label="Shared" Condition="Exists('..\Xamarin.Interactive.MTouch\Xamarin.Interactive.MTouch.projitems')" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Clients/Xamarin.Interactive.Client.Mac/AgentProcesses/iOSAgentProcess.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/AgentProcesses/iOSAgentProcess.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Interactive.Client.AgentProcesses
         async Task InitializeXcodeSdkAsync (IMessageService messageService)
         {
             try {
-                sdkRoot = MTouchSdkTool.GetXcodeSdkRoot ();
+                sdkRoot = await MTouchSdkTool.GetXcodeSdkRootAsync ();
             } catch (Exception e) {
                 Log.Error (TAG, e);
             }

--- a/Clients/Xamarin.Interactive.MTouch/MTouchSdkTool.cs
+++ b/Clients/Xamarin.Interactive.MTouch/MTouchSdkTool.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Interactive.MTouch
         const string XamarinStudioMlaunchPath = "/Applications/Xamarin Studio.app/Contents/Resources/lib/monodevelop/" +
             "AddIns/MonoDevelop.IPhone/mlaunch.app/Contents/MacOS/mlaunch";
         const string XamariniOSMlaunchPath = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch";
-        const string DefaultSdkRoot = "/Applications/Xcode.app/Contents/Developer";
+        const string DefaultSdkRoot = "/Applications/Xcode.app";
 
         public static readonly Version RequiredMinimumXcodeVersion = new Version (9, 0);
 

--- a/Package/Windows/ToolsFiles.wxs
+++ b/Package/Windows/ToolsFiles.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
     <ComponentGroup Id="ToolsComponents" Directory="ToolsInstallFolder">
-      <Component Id="Xamarin.Interactive.Mac.SimChecker.exe" Guid="2635679D-1D44-4BC5-99CE-6A9DCA3327CD">
-        <File Id="Xamarin.Interactive.Mac.SimChecker.exe" Source="$(var.Xamarin.Interactive.Client.Mac.SimChecker.TargetDir)\Xamarin.Interactive.Mac.SimChecker.exe"/>
+      <Component Id="Xamarin.Interactive.Client.Mac.SimChecker.exe" Guid="2635679D-1D44-4BC5-99CE-6A9DCA3327CD">
+        <File Id="Xamarin.Interactive.Client.Mac.SimChecker.exe" Source="$(var.Xamarin.Interactive.Client.Mac.SimChecker.TargetPath)"/>
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
On my system, I frequently see `plutil` requests hang for no apparent reason. Fixed process execution in `MTouchSdkTool` to have a proper async flow and logging, and to support timeouts and limited retries. Ideally, `Exec` would be updated to support these features, and `MTouchSdkTool` would just rely on that class. And ideally we would not have to call `plutil` at all. We can address these down the road.

Also fixed a mistake in the `DefaultSdkRoot` path that caused issues for Windows.