### PR TITLE
build: force separate Restore and Build targets

### DIFF
--- a/Package/Windows/AndroidAgentAppAssemblies.wxs
+++ b/Package/Windows/AndroidAgentAppAssemblies.wxs
@@ -668,9 +668,6 @@
       <Component Id="AndroidAgentApp.System.Globalization.Extensions.dll" Guid="6EC8BBB0-4309-45C5-9B7E-42809C958AF5">
         <File Id="AndroidAgentApp.System.Globalization.Extensions.dll" Source="$(var.AndroidAppAssembliesDir)\System.Globalization.Extensions.dll" />
       </Component>
-      <Component Id="AndroidAgentApp.System.Runtime.InteropServices.RuntimeInformation.dll" Guid="4FC9F01D-7021-4FCE-A3E0-5D21B16D46AE">
-        <File Id="AndroidAgentApp.System.Runtime.InteropServices.RuntimeInformation.dll" Source="$(var.AndroidAppAssembliesDir)\System.Runtime.InteropServices.RuntimeInformation.dll" />
-      </Component>
       <Component Id="AndroidAgentApp.System.Runtime.Serialization.Primitives.dll" Guid="99FAADCE-D106-4B0D-9E99-F2B23736B131">
         <File Id="AndroidAgentApp.System.Runtime.Serialization.Primitives.dll" Source="$(var.AndroidAppAssembliesDir)\System.Runtime.Serialization.Primitives.dll" />
       </Component>

--- a/WorkbookApps/Xamarin.Workbooks.Android/Build.targets
+++ b/WorkbookApps/Xamarin.Workbooks.Android/Build.targets
@@ -35,6 +35,25 @@
       SourceFiles="@(FrameworkFiles)"
       DestinationFolder="$(InstallDir)Android\Framework\%(RecursiveDir)"/>
 
+    <!--
+      Once again, Xamarin.Android has removed something from its Framework
+      bundle in a newer version that was previously there. Because AppVeyor
+      and VSTS are not exactly in sync, this file exists in the AppVeyor build
+      but no longer in the VSTS build (which results in a failure because the
+      file is declared in the WiX manifest, but doesn't exist).
+
+      This one makes sense - System.Runtime.InteropServices.RuntimeInformation
+      is a facade. It now only exists in the Facades directory, where previously
+      it was both in the main framework directory *and* the Facades directory.
+
+      History log for similar problems with Xamarin.Android:
+
+      March 23, 2018 - System.Reflection.Primitives.dll:
+        https://github.com/Microsoft/workbooks/commit/08ec163e4fcccbf45305dd52f0bef21c2b44dd2d
+    -->
+    <Delete
+      Files="$(InstallDir)Android\Framework\System.Runtime.InteropServices.RuntimeInformation.dll"/>
+
     <!-- Android workbook app files -->
     <UpdateWixManifest
       SourceDirectory="$(InstallDir)Android\Framework"

--- a/build.proj
+++ b/build.proj
@@ -1,4 +1,4 @@
-<Project InitialTargets="Configure" DefaultTargets="Restore;Build">
+<Project InitialTargets="Configure" DefaultTargets="Build">
   <Import Project="Directory.Build.props"/>
   <Import Project="Directory.Build.targets"/>
   <Import Project="build\Environment.targets"/>
@@ -16,6 +16,7 @@
     <SolutionFile>$(MSBuildThisFileDirectory)build\Xamarin.Interactive.sln</SolutionFile>
     <SolutionFileRelative>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory), $(SolutionFile)))</SolutionFileRelative>
     <SolutionBasePath>$([System.IO.Path]::GetDirectoryName($(SolutionFile)))\</SolutionBasePath>
+    <RestoreStampFile>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)_build\Restore.stamp'))</RestoreStampFile>
   </PropertyGroup>
 
   <!-- Profiles -->
@@ -167,6 +168,14 @@
   <!-- Solution Targets -->
 
   <Target
+    Name="CheckRestore"
+    BeforeTargets="Build">
+    <Error
+      Condition="!Exists('$(RestoreStampFile)')"
+      Text="When building with MSBuild directly, The 'Restore' target must be run first. Run 'msbuild /restore' or 'msbuild /t:Restore'."/>
+  </Target>
+
+  <Target
     Name="Build"
     DependsOnTargets="@(ProfileTargets)">
     <Exec Condition="$(IsWindows) And Exists('$(Adb)')" Command="$(Adb) kill-server"/>
@@ -183,6 +192,10 @@
     <MSBuild
       Projects="$(SolutionFile)"
       Targets="Restore"/>
+    <WriteLinesToFile
+      File="$(RestoreStampFile)"
+      Overwrite="true"
+      Lines="$([System.DateTime]::Now)"/>
   </Target>
 
   <!-- Profile Targets -->


### PR DESCRIPTION
At least provide a better and faster error message when restore isn't
run first.

Ugh. https://github.com/Microsoft/msbuild/issues/2455