### PR TITLE
Policheck: Exclude license.rtf

### DIFF
--- a/Build/Utility.targets
+++ b/Build/Utility.targets
@@ -214,6 +214,7 @@ Copyright 2017 Microsoft. All rights reserved.
       <PolicheckInput Remove="**\*.g.*" />
       <PolicheckInput Remove="**\Lorem Ipsum.txt" />
       <PolicheckInput Remove="**\*.bin" />
+      <PolicheckInput Remove="**\license.rtf" />
     </ItemGroup>
     <PropertyGroup>
       <PolicheckInputFile>$(MSBuildThisFileDirectory)..\PolicheckInput.txt</PolicheckInputFile>


### PR DESCRIPTION
This document comes straight from CELA and does not need to be checked.