### PR TITLE
Policheck: Exclude license.rtf

### DIFF
--- a/build/Utility.targets
+++ b/build/Utility.targets
@@ -184,6 +184,7 @@
       <PolicheckInput Remove="**\*.g.*" />
       <PolicheckInput Remove="**\Lorem Ipsum.txt" />
       <PolicheckInput Remove="**\*.bin" />
+      <PolicheckInput Remove="**\license.rtf" />
     </ItemGroup>
     <PropertyGroup>
       <PolicheckInputFile>$(TopDirectory)PolicheckInput.txt</PolicheckInputFile>


### PR DESCRIPTION
This document comes straight from CELA and does not need to be checked.