### PR TITLE
Client: Output correct click handler for exception toggles.

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Rendering/Renderers/CSharpTextRenderer.cs
+++ b/Clients/Xamarin.Interactive.Client/Rendering/Renderers/CSharpTextRenderer.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Interactive.Rendering.Renderers
             else
                 Writer.Write ("<div class=\"exception inner\">");
 
-            Writer.Write ("<h1 onclick=\"exceptionToggle(this)\">");
+            Writer.Write ("<h1 onclick=\"xiexports.exceptionToggle(this)\">");
 
             VisitTypeSpec (exception.Type);
 


### PR DESCRIPTION
Inner exceptions can't be expanded without this fix.