### PR TITLE
Win: Work around potential clipboard crash

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Windows/Views/MenuManager.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/Views/MenuManager.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Interactive.Client.Windows.Views
             helpMenu.Items.Add (new MenuItem {
                 Header = Catalog.GetString ("Copy Version Information"),
                 Command = new DelegateCommand (_ =>
-                    Clipboard.SetText (ClientApp.SharedInstance.IssueReport.GetEnvironmentMarkdown ())),
+                    Clipboard.SetDataObject (ClientApp.SharedInstance.IssueReport.GetEnvironmentMarkdown ())),
             });
 
             helpMenu.Items.Add (new Separator ());


### PR DESCRIPTION
Reported as part of https://github.com/Microsoft/workbooks/issues/459.

See also https://stackoverflow.com/questions/12769264/openclipboard-failed-when-copy-pasting-data-from-wpf-datagrid.