### PR TITLE
Win: Remove obsolete checks in NativeDependencyResolver

### DIFF
--- a/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/CodeAnalysis/Resolving/NativeDependencyResolver.cs
+++ b/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/CodeAnalysis/Resolving/NativeDependencyResolver.cs
@@ -31,8 +31,7 @@ namespace Xamarin.Interactive.CodeAnalysis.Resolving
         {
             CompilationConfiguration = compilationConfiguration;
 
-            agentArchitecture = Environment.Is64BitProcess &&
-                (HostEnvironment.OS != HostOS.Windows || compilationConfiguration.Sdk.IsNot (SdkId.ConsoleNetCore))
+            agentArchitecture = Environment.Is64BitProcess
                 ? Architecture.X64
                 : Architecture.X86;
         }


### PR DESCRIPTION
Because we ship a 64-bit .NET Core agent on Windows now.

This prevents an NRE as well.