### PR TITLE
Client: Set selectedView in shared code

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Desktop/ViewInspector/InspectTreeRoot.cs
+++ b/Clients/Xamarin.Interactive.Client.Desktop/ViewInspector/InspectTreeRoot.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Interactive.Client.ViewInspector
                     return;
 
                 selectedNode = value;
-                model.SelectedView = selectedNode?.View;
+                model.SelectView (selectedNode?.View, false, true);
                 NotifyPropertyChanged ();
             }
             get {

--- a/Clients/Xamarin.Interactive.Client.Desktop/ViewInspector/ViewInspectorViewModel.cs
+++ b/Clients/Xamarin.Interactive.Client.Desktop/ViewInspector/ViewInspectorViewModel.cs
@@ -178,11 +178,9 @@ namespace Xamarin.Interactive.Client.ViewInspector
         InspectView selectedView;
         public InspectView SelectedView {
             get { return selectedView; }
-            set {
+            private set {
                 if (selectedView != value) {
                     selectedView = value;
-                    if (selectedView != null)
-                        SelectView (selectedView, false, false);
                     OnPropertyChanged ();
                 }
             }
@@ -285,8 +283,14 @@ namespace Xamarin.Interactive.Client.ViewInspector
 
             RootView = root;
             RepresentedView = current;
-            if (setSelectedView)
+            if (setSelectedView) {
                 SelectedView = view;
+
+                if (!string.IsNullOrEmpty (view?.PublicCSharpType)
+                    && Session.SessionKind == ClientSessionKind.LiveInspection)
+                    Session.EvaluationService.EvaluateAsync (
+                        $"var selectedView = GetObject<{view.PublicCSharpType}> (0x{view.Handle:x})").Forget ();
+            }
         }
 
         protected void UpdateSupportedHierarchies (IEnumerable<string> hierarchies)

--- a/Clients/Xamarin.Interactive.Client.Desktop/ViewInspector/ViewInspectorViewModel.cs
+++ b/Clients/Xamarin.Interactive.Client.Desktop/ViewInspector/ViewInspectorViewModel.cs
@@ -267,8 +267,8 @@ namespace Xamarin.Interactive.Client.ViewInspector
             if (withinExistingTree && RootView != null && view != null)
                 view = RootView.FindSelfOrChild (v => v.Handle == view.Handle);
 
-            var root = view?.Root;
-            var current = view;
+            var root = view?.Root ?? RootView;
+            var current = view ?? RepresentedView;
 
             // find the "window" to represent in the 3D view by either
             // using the root node of the tree for trees with real roots,

--- a/Clients/Xamarin.Interactive.Client.Windows/AgentSessionWindow.xaml.cs
+++ b/Clients/Xamarin.Interactive.Client.Windows/AgentSessionWindow.xaml.cs
@@ -438,11 +438,6 @@ namespace Xamarin.Interactive.Client.Windows
 
             propertyEditor.SelectedItems.Clear ();
             propertyEditor.SelectedItems.Add (remoteProperty);
-
-            if (!string.IsNullOrEmpty (view?.PublicCSharpType)
-                && Session.SessionKind == ClientSessionKind.LiveInspection)
-                await Session.EvaluationService.EvaluateAsync (
-                    $"var selectedView = GetObject<{view.PublicCSharpType}> (0x{view.Handle:x})");
         }
 
         void OnClearHistory (object sender, ExecutedRoutedEventArgs e)


### PR DESCRIPTION
This was accidentally deleted from the Mac client in 1.4.0.

Force callers to go through `SetSelectedView` method to make the flow
safer and avoid situations where `SetSelectedView` got called an extra
time.

Fixes: https://github.com/Microsoft/workbooks/issues/456