### PR TITLE
Resolving: Fix another NRE

### DIFF
--- a/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/CodeAnalysis/Resolving/NativeDependencyResolver.cs
+++ b/CodeAnalysis/Xamarin.Interactive.CodeAnalysis/CodeAnalysis/Resolving/NativeDependencyResolver.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Interactive.CodeAnalysis.Resolving
             var resolvedAssembly = base.ParseAssembly (resolveOperation, path, peReader, metadataReader);
             var nativeDependencies = new List<ExternalDependency> ();
 
-            if (CompilationConfiguration.Sdk.Is (SdkId.XamarinIos))
+            if (CompilationConfiguration != null && CompilationConfiguration.Sdk.Is (SdkId.XamarinIos))
                 nativeDependencies.AddRange (
                     GetEmbeddedFrameworks (
                         resolveOperation,


### PR DESCRIPTION
Similar to https://github.com/Microsoft/workbooks/pull/467, this repeated NRE was really slowing down client startup on Windows when debugging.

Only impacts `master`.