### PR TITLE
Inspector: Add buildinfo to Windows nupkg (1.4)

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -535,6 +535,14 @@
       SourceFiles="@(InspectorClientFiles)"
       DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)Client\%(RecursiveDir)"/>
 
+    <ItemGroup>
+      <ExtraRootFiles Include="$(PackageOutputDir)buildinfo"/>
+    </ItemGroup>
+    <Copy
+      SkipUnchangedFiles="true"
+      SourceFiles="@(ExtraRootFiles)"
+      DestinationFolder="$(InspectorNuGetPackageWindowsContentDir)"/>
+
     <Copy
       SkipUnchangedFiles="true"
       SourceFiles="@(AndroidAgentFiles)"


### PR DESCRIPTION
Inspector extension tries to load this; good idea to ship regardless.