### PR TITLE
 iOS: Prefer iPhone X to iPhone 5s 

### DIFF
--- a/ClientIntegrations/Xamarin.Workbooks.Client.iOS/iOSAgentProcess.cs
+++ b/ClientIntegrations/Xamarin.Workbooks.Client.iOS/iOSAgentProcess.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -247,10 +248,10 @@ namespace Xamarin.Interactive.Client.AgentProcesses
             var mtouchList = MTouchSdkTool.ReadFromXml (
                 new MemoryStream (Encoding.UTF8.GetBytes (simCheckerResult.Result)));
 
-            var compatibleDevices = MTouchSdkTool.GetCompatibleDevices (mtouchList);
-            var simulatorDevice =
-                compatibleDevices.FirstOrDefault (d => d.Name == "iPhone X") ?? compatibleDevices.FirstOrDefault ();
-            deviceUdid = simulatorDevice?.UDID;
+            deviceUdid = MTouchSdkTool
+                .GetCompatibleDevices (mtouchList)
+                .FirstOrDefault ()
+                ?.UDID;
 
             if (deviceUdid == null)
                 throw new UserPresentableException (

--- a/ClientIntegrations/Xamarin.Workbooks.Client.iOS/iOSAgentProcess.cs
+++ b/ClientIntegrations/Xamarin.Workbooks.Client.iOS/iOSAgentProcess.cs
@@ -244,13 +244,13 @@ namespace Xamarin.Interactive.Client.AgentProcesses
                     simCheckerResult.Error);
             }
 
-            foreach (var resultLine in simCheckerResult.Result.Split (Environment.NewLine.ToCharArray (), StringSplitOptions.RemoveEmptyEntries)) {
-                var line = resultLine.Trim ();
-                if (line.StartsWith ("UDID: ")) {
-                    deviceUdid = line.Substring (6);
-                    break;
-                }
-            }
+            var mtouchList = MTouchSdkTool.ReadFromXml (
+                new MemoryStream (Encoding.UTF8.GetBytes (simCheckerResult.Result)));
+
+            var compatibleDevices = MTouchSdkTool.GetCompatibleDevices (mtouchList);
+            var simulatorDevice =
+                compatibleDevices.FirstOrDefault (d => d.Name == "iPhone X") ?? compatibleDevices.FirstOrDefault ();
+            deviceUdid = simulatorDevice?.UDID;
 
             if (deviceUdid == null)
                 throw new UserPresentableException (

--- a/Clients/Xamarin.Interactive.Client.Mac.SimChecker/Program.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac.SimChecker/Program.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
 
 using Xamarin.Interactive.Logging;
 using Xamarin.Interactive.MTouch;
@@ -56,22 +58,15 @@ namespace Xamarin.Interactive.Mac.SimChecker
                 return;
             }
 
-            IEnumerable<MTouchListSimXml.SimDeviceElement> compatibleDevices;
             try {
-                compatibleDevices = MTouchSdkTool.GetCompatibleDevices (mtouchList);
+                // compatibleDevices = MTouchSdkTool.GetCompatibleDevices (mtouchList);
+                var x = new XmlSerializer (typeof (MTouchListSimXml));
+                x.Serialize (Console.Out, mtouchList);
             } catch (Exception e) {
                 Console.Error.WriteLine (e.Message);
                 Environment.Exit (103); // Invalid mlaunch output
                 return;
             }
-
-            var firstCompatibleDevice = compatibleDevices?.FirstOrDefault ();
-            if (firstCompatibleDevice == null) {
-                Console.Error.WriteLine ("No compatible simulator devices installed");
-                Environment.Exit (104); // No compatible sim listed by mlaunch
-            }
-
-            Console.WriteLine ($"UDID: {firstCompatibleDevice.UDID}");
         }
     }
 }

--- a/Clients/Xamarin.Interactive.Client.Mac/AgentProcesses/iOSAgentProcess.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/AgentProcesses/iOSAgentProcess.cs
@@ -146,9 +146,9 @@ namespace Xamarin.Interactive.Client.AgentProcesses
                 .Select (r => r.Name.Replace ("iOS ", ""))
                 .LastOrDefault ();
 
-            var compatibleDevices = MTouchSdkTool.GetCompatibleDevices (mtouchList);
-            simulatorDevice =
-                compatibleDevices.FirstOrDefault (d => d.Name == "iPhone X") ?? compatibleDevices.FirstOrDefault ();
+            simulatorDevice = MTouchSdkTool
+                .GetCompatibleDevices (mtouchList)
+                .FirstOrDefault ();
 
             if (simulatorDevice != null && defaultSdkVersion != null)
                 return;

--- a/Clients/Xamarin.Interactive.Client.Mac/AgentProcesses/iOSAgentProcess.cs
+++ b/Clients/Xamarin.Interactive.Client.Mac/AgentProcesses/iOSAgentProcess.cs
@@ -33,10 +33,9 @@ namespace Xamarin.Interactive.Client.AgentProcesses
     {
         const string TAG = nameof (iOSAgentProcess);
 
-        const string simulatorDevice = "iphone,64";
-
         FilePath sdkRoot;
         string defaultSdkVersion;
+        MTouchListSimXml.SimDeviceElement simulatorDevice;
 
         NSTask mlaunchProcess;
         NSObject terminatedObserver;
@@ -72,7 +71,7 @@ namespace Xamarin.Interactive.Client.AgentProcesses
                 "-sdkroot", sdkRoot,
                 "-launchsim", WorkbookApp.AppPath,
                 "-sdk", defaultSdkVersion,
-                "-device", simulatorDevice
+                "-device", $":v2:udid={simulatorDevice.UDID}"
             };
 
             mlaunchArguments.AddRange (identifyAgentRequest
@@ -147,7 +146,11 @@ namespace Xamarin.Interactive.Client.AgentProcesses
                 .Select (r => r.Name.Replace ("iOS ", ""))
                 .LastOrDefault ();
 
-            if (defaultSdkVersion != null)
+            var compatibleDevices = MTouchSdkTool.GetCompatibleDevices (mtouchList);
+            simulatorDevice =
+                compatibleDevices.FirstOrDefault (d => d.Name == "iPhone X") ?? compatibleDevices.FirstOrDefault ();
+
+            if (simulatorDevice != null && defaultSdkVersion != null)
                 return;
 
             throw new UserPresentableException (Catalog.GetString ("No iOS simulators found."));

--- a/Clients/Xamarin.Interactive.MTouch/MTouchListSimXml.cs
+++ b/Clients/Xamarin.Interactive.MTouch/MTouchListSimXml.cs
@@ -5,6 +5,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Xml.Serialization;
 
 namespace Xamarin.Interactive.MTouch
@@ -43,7 +44,7 @@ namespace Xamarin.Interactive.MTouch
             public bool Supports64Bits { get; set; }
         }
 
-        public class SimDeviceElement
+        public class SimDeviceElement : IComparable<SimDeviceElement>
         {
             [XmlAttribute]
             public string UDID { get; set; }
@@ -54,6 +55,19 @@ namespace Xamarin.Interactive.MTouch
             public string SimRuntime { get; set; }
 
             public string SimDeviceType { get; set; }
+
+            public int CompareTo (SimDeviceElement other)
+            {
+                if (other == null)
+                    return -1;
+
+                // NOTE: This is copied from IPhoneSimulatorExecutionTargetGroup in VSmac.
+                //
+                // Treating iPhone X (ten) as iPhone 10 makes it so 'iPhone 7 < iPhone 8 < iPhone X'
+                var name = Name.Replace ("X", "10");
+                var otherName = other.Name.Replace ("X", "10");
+                return string.Compare (name, otherName, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         public string SdkRoot { get; set; }

--- a/Clients/Xamarin.Interactive.MTouch/MTouchSdkTool.cs
+++ b/Clients/Xamarin.Interactive.MTouch/MTouchSdkTool.cs
@@ -162,6 +162,7 @@ namespace Xamarin.Interactive.MTouch
                 join t in simInfo.SupportedDeviceTypes on d.SimDeviceType equals t.Identifier
                 where t.ProductFamilyId == "IPhone"
                 where t.Supports64Bits
+                orderby d
                 select d;
             return devices.ToList ();
         }


### PR DESCRIPTION
Client integrations now have access to all available devices, as well.

This changes SimChecker output to be incompatible with Workbooks < 1.2
(when Windows still required a Workbooks install on the Mac host).