### PR TITLE
Client: Cache global state assemblies by name

### DIFF
--- a/Agents/Xamarin.Interactive/CodeAnalysis/EvaluationContextInitializeRequest.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/EvaluationContextInitializeRequest.cs
@@ -38,6 +38,9 @@ namespace Xamarin.Interactive.CodeAnalysis
                 var globalStateType = evaluationContext.GlobalState.GetType ();
                 response.GlobalStateTypeName = globalStateType.FullName;
 
+                // TODO: Why is globalStateType.Assembly.Location null when you
+                //       create a non-XF workbook after creating an XF workbook?
+
                 // HACK: This is a temporary fix to get iOS agent/app assemblies sent to the
                 //       Windows client when using the remote sim.
                 var peImage = IncludePeImage && File.Exists (globalStateType.Assembly.Location)


### PR DESCRIPTION
1. Open Workbooks
2. Create a XF iOS workbook
3. Create a non-XF iOS workbook

The second workbook, for whatever reason, doesn't set a PEImage for the
global state assembly, so the client tries to resolve it from a different
location, leading to an exception.

Cache to avoid this. Will be nice when this reflection loading can go away.