### PR TITLE
Telemetry: use machine ID as user context for app insights

### DIFF
--- a/Clients/Xamarin.Interactive.Client/Telemetry/Client.cs
+++ b/Clients/Xamarin.Interactive.Client/Telemetry/Client.cs
@@ -81,6 +81,9 @@ namespace Xamarin.Interactive.Telemetry
 
                 appInsightsClient.Context.Session.Id = sessionid.ToString ();
                 appInsightsClient.Context.Device.OperatingSystem = host.OSName.ToString ();
+                appInsightsClient.Context.User.Id = Sha256Hasher.Hash (MacAddressGetter.GetMacAddress ());
+
+                Log.Info (TAG, $"Machine ID: {appInsightsClient.Context.User.Id}");
 
                 // TODO: Make these GlobalProperties when we bump to 2.7.0-beta3 or later
                 var globalProperties = appInsightsClient.Context.Properties;
@@ -113,7 +116,7 @@ namespace Xamarin.Interactive.Telemetry
                     BuildInfo.Version.CandidateLevel.ToString ().ToLowerInvariant ());
                 globalProperties.Add (
                     "Machine ID",
-                    Sha256Hasher.Hash (MacAddressGetter.GetMacAddress ()));
+                    appInsightsClient.Context.User.Id);
                 globalProperties.Add (
                     "Update Channel", updater.UpdateChannel);
 


### PR DESCRIPTION
Unfortunately I didn't notice this before 1.4.2 so we still need to send a custom Machine ID property. We should have never had that as a custom property and used the user context as intended. Sigh.