### PR TITLE
Save workbook changes - allow workbooks with dependencies to be saved independently of their dependencies

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Windows/Xamarin.Interactive.Client.Windows.csproj
+++ b/Clients/Xamarin.Interactive.Client.Windows/Xamarin.Interactive.Client.Windows.csproj
@@ -94,6 +94,12 @@
     <PackageReference Include="MouseKeyboardActivityMonitor">
       <Version>4.0.5150.10665</Version>
     </PackageReference>
+    <PackageReference Include="WindowsAPICodePack-Core">
+      <Version>1.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="WindowsAPICodePack-Shell">
+      <Version>1.1.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="App.xaml">
@@ -263,14 +269,6 @@
     <ProjectReference Include="..\..\External\CommonMark.NET\CommonMark\CommonMark.Base.csproj">
       <Project>{0fd4b1dd-45a8-4f02-beb0-5881cd512573}</Project>
       <Name>CommonMark.Base</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\External\WindowsAPICodePack\Core\Core.csproj">
-      <Project>{2e1fb0df-f9bb-4909-9f32-2d9d022a8e57}</Project>
-      <Name>Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\External\WindowsAPICodePack\Shell\Shell.csproj">
-      <Project>{aa0c00cb-8699-4f37-bfae-40ca87acc06d}</Project>
-      <Name>Shell</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\External\Xamarin.PropertyEditing\Xamarin.PropertyEditing.Windows\Xamarin.PropertyEditing.Windows.csproj">
       <Project>{60af04be-1b6b-411b-bcba-c95eafbd7ac0}</Project>

--- a/Clients/Xamarin.Interactive.Client/Workbook/LoadAndSave/IWorkbookSaveOperation.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/LoadAndSave/IWorkbookSaveOperation.cs
@@ -11,8 +11,10 @@ namespace Xamarin.Interactive.Workbook.LoadAndSave
 {
     interface IWorkbookSaveOperation
     {
-        WorkbookSaveOptions SupportedOptions { get; }
-        WorkbookSaveOptions Options { get; set; }
+        bool SupportsMultiFileOptions { get; }
+        bool SupportsSingleFileOption { get; }
+        bool InvolesMultipleFiles { get; }
+        WorkbookSaveOptions SaveOption { get; set; }
         FilePath Destination { get; set; }
     }
 }

--- a/Clients/Xamarin.Interactive.Client/Workbook/LoadAndSave/WorkbookSaveOptions.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/LoadAndSave/WorkbookSaveOptions.cs
@@ -9,11 +9,10 @@ using System;
 
 namespace Xamarin.Interactive.Workbook.LoadAndSave
 {
-    [Flags]
     enum WorkbookSaveOptions
     {
-        None = 0,
-        Archive = 1 << 0,
-        Sign = 1 << 1
+        SingleWorkbookFile = 0,
+        Archive = 1,
+        PackageDirectory = 2
     }
 }

--- a/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPackage.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPackage.cs
@@ -249,7 +249,7 @@ namespace Xamarin.Interactive.Workbook.Models
             if (quarantineInfoHandler == null)
                 throw new ArgumentNullException (nameof (quarantineInfoHandler));
 
-            SaveOptions = WorkbookSaveOptions.None;
+            SaveOptions = WorkbookSaveOptions.SingleWorkbookFile;
             LogicalPath = openPath;
 
             QuarantineInfo quarantineInfo = null;
@@ -300,7 +300,7 @@ namespace Xamarin.Interactive.Workbook.Models
             if (isDirectory) {
                 indexPage.Path = indexPageFileName;
                 readPath = openPath.Combine (indexPage.Path);
-                openedFromDirectory = true;
+                SaveOptions = WorkbookSaveOptions.PackageDirectory;
             } else {
                 // If we are opening a file within a .workbook directory somewhere,
                 // actually open that directory. This is to mostly address issues
@@ -323,6 +323,7 @@ namespace Xamarin.Interactive.Workbook.Models
 
                 indexPage.Path = openPath.Name;
                 readPath = openPath;
+                SaveOptions = WorkbookSaveOptions.SingleWorkbookFile;
             }
 
             using (var stream = new FileStream (
@@ -361,7 +362,7 @@ namespace Xamarin.Interactive.Workbook.Models
 
             Open (extractPath, true, platformTargets);
 
-            SaveOptions |= WorkbookSaveOptions.Archive;
+            SaveOptions = WorkbookSaveOptions.Archive;
         }
 
         FilePath GetTempZipArchivePath ()
@@ -377,16 +378,28 @@ namespace Xamarin.Interactive.Workbook.Models
             public WorkbookPage OnlyPage;
             public bool OnlyPageHasDependencies;
 
-            public WorkbookSaveOptions SupportedOptions {
+            public bool InvolesMultipleFiles {
                 get {
-                    if (OnlyPage == null || OnlyPageHasDependencies)
-                        return WorkbookSaveOptions.Archive;
-
-                    return WorkbookSaveOptions.None;
+                    return (OnlyPage == null || OnlyPageHasDependencies);
                 }
             }
 
-            public WorkbookSaveOptions Options { get; set; }
+            public bool SupportsMultiFileOptions {
+                get {
+                    // actually it seems, we always can have multifile options...
+                    return true;
+                }
+            }
+
+            public bool SupportsSingleFileOption {
+                get {
+                    // actually it seems, we always can have singlefile options...
+                    // - or do I misunderstand what "OnlyPage == null" means...
+                    return true;
+                }
+            }
+
+            public WorkbookSaveOptions SaveOption { get; set; }
             public FilePath Destination { get; set; }
         }
 
@@ -400,7 +413,7 @@ namespace Xamarin.Interactive.Workbook.Models
                 AllDependencies = dependencies,
                 OnlyPage = onlyPage.Key,
                 OnlyPageHasDependencies = onlyPage.Key != null && onlyPage.Value.Count > 0,
-                Options = SaveOptions
+                SaveOption = SaveOptions
             };
         }
 
@@ -411,19 +424,13 @@ namespace Xamarin.Interactive.Workbook.Models
                 throw new ArgumentNullException (nameof (operation));
 
             LogicalPath = operation.Destination;
-            SaveOptions = WorkbookSaveOptions.None;
+            SaveOptions = operation.SaveOption;
 
             if (IndexPage != null)
                 IndexPage.Title = LogicalPath.NameWithoutExtension;
 
-            if (saveOperation.OnlyPage != null &&
-                !saveOperation.OnlyPageHasDependencies &&
-                !openedFromDirectory) {
-                // The workbook package has only a single page with no relative
-                // dependencies. If the original path was a workbook directory,
-                // keep that format. If we originally opened from a workbook
-                // directory and our target save path is not a directory, keep
-                // that format. Otherwise, save the page as a single file.
+            if (saveOperation.SaveOption == WorkbookSaveOptions.SingleWorkbookFile) {
+                // This is a simple save... so we ignore dependencies
                 var writePath = logicalPath.DirectoryExists
                     ? logicalPath.Combine (saveOperation.OnlyPage.Path)
                     : logicalPath;
@@ -471,12 +478,12 @@ namespace Xamarin.Interactive.Workbook.Models
                 }
             }
 
-            if (saveOperation.Options.HasFlag (WorkbookSaveOptions.Archive))
+            if (saveOperation.SaveOption == WorkbookSaveOptions.Archive)
                 ArchiveDirectory (logicalPath);
 
             // For overwrite saves of archives, WorkingPath should continue
             // to point to the extracted directory in temp
-            if (!saveOperation.Options.HasFlag (WorkbookSaveOptions.Archive) ||
+            if ((saveOperation.SaveOption != WorkbookSaveOptions.Archive) ||
                 WorkingPath == null ||
                 !WorkingPath.Exists)
                 WorkingPath = logicalPath;
@@ -499,8 +506,6 @@ namespace Xamarin.Interactive.Workbook.Models
 
         void ArchiveDirectory (FilePath directory)
         {
-            SaveOptions |= WorkbookSaveOptions.Archive;
-
             var archivePath = GetTempZipArchivePath ();
 
             using (var stream = new FileStream (

--- a/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPackage.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPackage.cs
@@ -413,7 +413,7 @@ namespace Xamarin.Interactive.Workbook.Models
             LogicalPath = operation.Destination;
             SaveOptions = WorkbookSaveOptions.None;
 
-            if (IndexPage != null && IndexPage.IsUntitled)
+            if (IndexPage != null)
                 IndexPage.Title = LogicalPath.NameWithoutExtension;
 
             if (saveOperation.OnlyPage != null &&

--- a/Package/Windows/AgentAppFiles.wxs
+++ b/Package/Windows/AgentAppFiles.wxs
@@ -300,17 +300,18 @@
       <Component Id="WpfAgentApp.System.Xml.XPath.XDocument.dll" Guid="54907165-7367-4BFB-AF25-88BBFE04AE0E">
         <File Id="WpfAgentApp.System.Xml.XPath.XDocument.dll" Source="$(var.WpfAgentAppDirectory)\System.Xml.XPath.XDocument.dll" />
       </Component>
+      <Component Id="WpfAgentApp.Microsoft.WindowsAPICodePack.dll" Guid="DC2BA773-3248-4AF3-ACE8-F9EB248A1A09">
+        <File Id="WpfAgentApp.Microsoft.WindowsAPICodePack.dll" Source="$(var.WpfAgentAppDirectory)\Microsoft.WindowsAPICodePack.dll" />
+      </Component>
     </ComponentGroup>
-
     <?ifdef AndroidSupport ?>
-      <?define AndroidAgentAppDirectory="..\..\_build\$(var.Configuration)\WorkbookApps\Android" ?>
-      <ComponentGroup Id="AndroidAgentAppComponents" Directory="AndroidAgentAppInstallFolder">
-        <Component Id="AndroidAgentApp.apk" Guid="6CD2D3A9-40D7-4583-BDD1-5B4711431381">
-          <File Id="AndroidAgentApp.apk" Source="$(var.AndroidAgentAppDirectory)\com.xamarin.workbook_app_android-Signed.apk" />
-        </Component>
-      </ComponentGroup>
+    <?define AndroidAgentAppDirectory="..\..\_build\$(var.Configuration)\WorkbookApps\Android" ?>
+    <ComponentGroup Id="AndroidAgentAppComponents" Directory="AndroidAgentAppInstallFolder">
+      <Component Id="AndroidAgentApp.apk" Guid="6CD2D3A9-40D7-4583-BDD1-5B4711431381">
+        <File Id="AndroidAgentApp.apk" Source="$(var.AndroidAgentAppDirectory)\com.xamarin.workbook_app_android-Signed.apk" />
+      </Component>
+    </ComponentGroup>
     <?endif?>
-
     <ComponentGroup Id="WorkbookManifestComponents" Directory="AgentAppInstallFolder">
       <Component Id="workbookapps.json" Guid="47A8314B-0E4A-48BD-AA24-84A18AE06291">
         <File Id="workbookapps.json" Source="..\..\_build\$(var.Configuration)\WorkbookApps\workbookapps.json" />

--- a/Package/Windows/DotNetCoreAgentAppFiles-win-x86.wxs
+++ b/Package/Windows/DotNetCoreAgentAppFiles-win-x86.wxs
@@ -664,6 +664,12 @@
       <Component Id="DNCAgentAppwinx86.System.Memory.dll" Guid="FDA9A09B-F94B-4509-BAB8-919511A724DF">
         <File Id="DNCAgentAppwinx86.System.Memory.dll" Source="$(var.DotNetCoreAssembliesDir)\System.Memory.dll" />
       </Component>
+      <Component Id="DNCAgentAppwinx86.mscordaccore_x86_x86_4.6.26515.07.dll" Guid="A79CC6CE-1A0A-4FCC-9EE9-B40A26274239">
+        <File Id="DNCAgentAppwinx86.mscordaccore_x86_x86_4.6.26515.07.dll" Source="$(var.DotNetCoreAssembliesDir)\mscordaccore_x86_x86_4.6.26515.07.dll" />
+      </Component>
+      <Component Id="DNCAgentAppwinx86.sos_x86_x86_4.6.26515.07.dll" Guid="B4810B78-BFF9-41CD-98FD-38674A4BB261">
+        <File Id="DNCAgentAppwinx86.sos_x86_x86_4.6.26515.07.dll" Source="$(var.DotNetCoreAssembliesDir)\sos_x86_x86_4.6.26515.07.dll" />
+      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/WorkbookApps/Xamarin.Workbooks.Wpf/Xamarin.Workbooks.Wpf.csproj
+++ b/WorkbookApps/Xamarin.Workbooks.Wpf/Xamarin.Workbooks.Wpf.csproj
@@ -60,6 +60,9 @@
     <PackageReference Include="System.ValueTuple">
       <Version>4.4.0</Version>
     </PackageReference>
+    <PackageReference Include="WindowsAPICodePack-Core">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">


### PR DESCRIPTION
This change is slightly larger, but looks to address the file saving behavior in #500 

This PR is not ready to merge yet. It requires review by Xamarin, plus it would require work in other clients (e.g. Mac) before it could be merged. Currently only WPF has been implemented.

Things to consider:

- [ ] Do Xamarin want this behaviour?
- [ ] Is it OK that I removed the `Signed` save option? (it wasn't used in Windows at least)
- [ ] Does this change work OK for scenarios where (for example) the user wants to saveas from a workbook package directory into a workbook?
- [ ] Does this change tie with the long term vision of the workbook roadmap?
- [ ] A whole lot of other things I haven't thought about!

Overall, I'm not sure this PR will ever get fully merged.... but I'm putting it in for consideration...