### PR TITLE
A globalVariables view

### DIFF
--- a/Agents/Xamarin.Interactive/API/Xamarin.Interactive.api.cs
+++ b/Agents/Xamarin.Interactive/API/Xamarin.Interactive.api.cs
@@ -283,6 +283,13 @@ namespace Xamarin.Interactive.CodeAnalysis
         object Result {
             get;
         }
+        SimpleVariable[] GlobalVariables { get; }
+    }
+    public struct SimpleVariable
+    {
+        public string FieldName { get; set; }
+        public object Value { get; set; }
+        public string ValueReadException { get; set; }
     }
     public interface IEvaluationContext
     {

--- a/Agents/Xamarin.Interactive/CodeAnalysis/Evaluation.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/Evaluation.cs
@@ -6,7 +6,7 @@
 // Licensed under the MIT License.
 
 using System;
-
+using System.Collections.Generic;
 using Xamarin.Interactive.Protocol;
 using Xamarin.Interactive.Representations.Reflection;
 
@@ -37,5 +37,6 @@ namespace Xamarin.Interactive.CodeAnalysis
         public int UICultureLCID { get; set; }
         public bool InitializedAgentIntegration { get; set; }
         public AssemblyDefinition [] LoadedAssemblies { get; set; }
+        public SimpleVariable[] GlobalVariables { get; set; }
     }
 }

--- a/Agents/Xamarin.Interactive/CodeAnalysis/EvaluationContext.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/EvaluationContext.cs
@@ -145,8 +145,13 @@ namespace Xamarin.Interactive.CodeAnalysis
                 // captured output back to the client for rendering.
                 stopwatch.Start ();
                 result.Result = await CoreRunAsync (compilation, cancellationToken);
-                result.GlobalVariables = GetGlobalVariables ()?.Select(v =>
-                        new SimpleVariable() { FieldName  = v.Field.Name, Value = v.Value, ValueReadException = v.ValueReadException?.ToString() })
+                result.GlobalVariables = 
+                    GetGlobalVariables ()?.Select(v =>
+                        new SimpleVariable() {
+                            FieldName  = v.Field.Name,
+                            Value = agent.RepresentationManager.Prepare(v.Value),
+                            ValueReadException = v.ValueReadException?.ToString()
+                        })
                     .ToArray();
             } catch (AggregateException e) when (e.InnerExceptions?.Count == 1) {
                 evaluationException = e;

--- a/Agents/Xamarin.Interactive/CodeAnalysis/IEvaluation.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/IEvaluation.cs
@@ -28,5 +28,12 @@ namespace Xamarin.Interactive.CodeAnalysis
         /// representation value.
         /// </summary>
         object Result { get; }
+        SimpleVariable [] GlobalVariables { get; }
+    }
+    public struct SimpleVariable
+    {
+        public string FieldName { get; set; }
+        public object Value { get; set; }
+        public string ValueReadException { get; set; }
     }
 }

--- a/Agents/Xamarin.Interactive/CodeAnalysis/IEvaluation.cs
+++ b/Agents/Xamarin.Interactive/CodeAnalysis/IEvaluation.cs
@@ -5,6 +5,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Xamarin.Interactive.CodeAnalysis
 {
     /// <summary>
@@ -30,6 +32,8 @@ namespace Xamarin.Interactive.CodeAnalysis
         object Result { get; }
         SimpleVariable [] GlobalVariables { get; }
     }
+
+    [Serializable]
     public struct SimpleVariable
     {
         public string FieldName { get; set; }

--- a/Clients/Xamarin.Interactive.Client.Windows/Xamarin.Interactive.Client.Windows.csproj
+++ b/Clients/Xamarin.Interactive.Client.Windows/Xamarin.Interactive.Client.Windows.csproj
@@ -94,6 +94,12 @@
     <PackageReference Include="MouseKeyboardActivityMonitor">
       <Version>4.0.5150.10665</Version>
     </PackageReference>
+    <PackageReference Include="WindowsAPICodePack-Core">
+      <Version>1.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="WindowsAPICodePack-Shell">
+      <Version>1.1.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="App.xaml">
@@ -263,14 +269,6 @@
     <ProjectReference Include="..\..\External\CommonMark.NET\CommonMark\CommonMark.Base.csproj">
       <Project>{0fd4b1dd-45a8-4f02-beb0-5881cd512573}</Project>
       <Name>CommonMark.Base</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\External\WindowsAPICodePack\Core\Core.csproj">
-      <Project>{2e1fb0df-f9bb-4909-9f32-2d9d022a8e57}</Project>
-      <Name>Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\External\WindowsAPICodePack\Shell\Shell.csproj">
-      <Project>{aa0c00cb-8699-4f37-bfae-40ca87acc06d}</Project>
-      <Name>Shell</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\External\Xamarin.PropertyEditing\Xamarin.PropertyEditing.Windows\Xamarin.PropertyEditing.Windows.csproj">
       <Project>{60af04be-1b6b-411b-bcba-c95eafbd7ac0}</Project>

--- a/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPageViewModel.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPageViewModel.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -25,6 +26,8 @@ using Xamarin.Interactive.Protocol;
 using Xamarin.Interactive.Representations;
 using Xamarin.Interactive.Representations.Reflection;
 using Xamarin.Interactive.Workbook.Views;
+using StackFrame = Xamarin.Interactive.Representations.Reflection.StackFrame;
+using StackTrace = Xamarin.Interactive.Representations.Reflection.StackTrace;
 
 namespace Xamarin.Interactive.Workbook.Models
 {
@@ -615,10 +618,27 @@ namespace Xamarin.Interactive.Workbook.Models
                     result.ResultHandling);
         }
 
+        void UpdateGlobalVariables (SimpleVariable[] resultGlobalVariables)
+        {
+            if (resultGlobalVariables == null) {
+                Debug.WriteLine ("No Global Variables available...");
+                return;
+            } else {
+                Debug.WriteLine ("Global Variables available...");
+                Debug.WriteLine ("-----------------------------");
+                foreach (var v in resultGlobalVariables) {
+                    Debug.WriteLine($"{v.FieldName} {v.Value} {v.ValueReadException}");
+                }
+
+            }
+        }
+
         void RenderResult (Evaluation result)
         {
             if (result == null)
                 return;
+
+            UpdateGlobalVariables (result.GlobalVariables);
 
             var codeCellState = GetCodeCellStateById (result.CodeCellId);
             if (codeCellState == null)

--- a/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPageViewModel.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Models/WorkbookPageViewModel.cs
@@ -159,6 +159,7 @@ namespace Xamarin.Interactive.Workbook.Models
 
         void LoadWorkbookCells ()
         {
+            CreateAndInsertGlobalsCell ();
             foreach (var cell in WorkbookPage.Contents) {
                 switch (cell) {
                 case CodeCell codeCell:
@@ -169,6 +170,14 @@ namespace Xamarin.Interactive.Workbook.Models
                     break;
                 }
             }
+        }
+
+        protected virtual void CreateAndInsertGlobalsCell ()
+        {
+        }
+
+        protected virtual void UpdateGlobals (SimpleVariable [] globals)
+        {
         }
 
         protected CodeCellState InsertCodeCell (Cell previousCell)
@@ -224,6 +233,7 @@ namespace Xamarin.Interactive.Workbook.Models
 
             InsertCellInViewModel (newCell, previousCell);
         }
+
 
         void InsertCellInDocumentModel (Cell newCell, Cell previousCell)
         {
@@ -629,8 +639,8 @@ namespace Xamarin.Interactive.Workbook.Models
                 foreach (var v in resultGlobalVariables) {
                     Debug.WriteLine($"{v.FieldName} {v.Value} {v.ValueReadException}");
                 }
-
             }
+            UpdateGlobals(resultGlobalVariables);
         }
 
         void RenderResult (Evaluation result)

--- a/Clients/Xamarin.Interactive.Client/Workbook/Views/GlobalsCellView.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Views/GlobalsCellView.cs
@@ -1,0 +1,67 @@
+// Contributed under the MIT License.
+
+using System;
+using System.Globalization;
+using Xamarin.CrossBrowser;
+using Xamarin.Interactive.Editor;
+using Xamarin.Interactive.Rendering;
+using Xamarin.Interactive.CodeAnalysis;
+
+namespace Xamarin.Interactive.Workbook.Views
+{
+    sealed class GlobalsCellView : CellView
+    {
+        HtmlElement resultElem;
+        readonly RendererContext rendererContext;
+
+        public GlobalsCellView (
+            HtmlDocument document
+            , RendererContext rendererContext) : base (
+            document,
+            "submission csharp")
+        {
+            //var container = Document.CreateElement ("div", "editor");
+            //container.InnerHTML = "HELLO WORLD";
+            //System.Threading.SynchronizationContext.Current.Post (o => ((dynamic)container).style.opacity = 1, null);
+            //ContentElement.AppendChild(container);
+            ContentElement.AppendChild (resultElem = CreateContentContainer ("results"));
+            this.rendererContext = rendererContext
+                                   ?? throw new ArgumentNullException (nameof (rendererContext));
+        }
+
+        static void RemoveElement (ref HtmlElement element)
+        {
+            element?.ParentElement?.RemoveChild (element);
+            element = null;
+        }
+
+        public void Reset ()
+        {
+            RemoveElement (ref resultElem);
+        }
+
+
+        public void RenderResult (
+            CultureInfo cultureInfo,
+            SimpleVariable [] results)
+        {
+            resultElem.RemoveChildren ();
+
+            // would be nice to pass in a single thing here really
+            // - so work more like GlobalVars...
+            foreach (var result in results) {
+                var childElem = CreateContentContainer ("result");
+                resultElem.AppendChild (childElem);
+                rendererContext.Render (
+                    RenderState.Create (result.Value, cultureInfo),
+                    childElem);
+            }
+        }
+
+        public override IEditor Editor => null;
+        public override void Focus (bool scrollIntoView = true)
+        {
+            // empty!
+        }
+    }
+}

--- a/Clients/Xamarin.Interactive.Client/Workbook/Views/XcbWorkbookPageView.cs
+++ b/Clients/Xamarin.Interactive.Client/Workbook/Views/XcbWorkbookPageView.cs
@@ -196,6 +196,18 @@ namespace Xamarin.Interactive.Workbook.Views
             cell.View = view;
         }
 
+        GlobalsCellView _globalsCellView;
+
+        protected override void CreateAndInsertGlobalsCell ()
+        {
+            // not used... went a different way...
+        }
+
+        protected override void UpdateGlobals (SimpleVariable [] globals)
+        {
+            _globalsCellView?.RenderResult(CultureInfo.CurrentUICulture, globals);
+        }
+
         protected override void BindCodeCellToView (CodeCell cell, CodeCellState codeCellState)
         {
             var codeCellView = new CodeCellView (
@@ -336,7 +348,9 @@ namespace Xamarin.Interactive.Workbook.Views
         void AppendFirstCellActions (HtmlElement parentElem)
         {
             var document = webView.Document;
-            firstCellActionsArticle = document.CreateElement ("article");
+            _globalsCellView = new GlobalsCellView (webView.Document, rendererContext);
+            firstCellActionsArticle = _globalsCellView.RootElement;
+            //firstCellActionsArticle = document.CreateElement ("article");
             parentElem.AppendChild (firstCellActionsArticle);
 
             var firstCellActionsFooter = document.CreateElement ("footer");

--- a/Package/Windows/AgentAppFiles.wxs
+++ b/Package/Windows/AgentAppFiles.wxs
@@ -300,17 +300,18 @@
       <Component Id="WpfAgentApp.System.Xml.XPath.XDocument.dll" Guid="54907165-7367-4BFB-AF25-88BBFE04AE0E">
         <File Id="WpfAgentApp.System.Xml.XPath.XDocument.dll" Source="$(var.WpfAgentAppDirectory)\System.Xml.XPath.XDocument.dll" />
       </Component>
+      <Component Id="WpfAgentApp.Microsoft.WindowsAPICodePack.dll" Guid="DC2BA773-3248-4AF3-ACE8-F9EB248A1A09">
+        <File Id="WpfAgentApp.Microsoft.WindowsAPICodePack.dll" Source="$(var.WpfAgentAppDirectory)\Microsoft.WindowsAPICodePack.dll" />
+      </Component>
     </ComponentGroup>
-
     <?ifdef AndroidSupport ?>
-      <?define AndroidAgentAppDirectory="..\..\_build\$(var.Configuration)\WorkbookApps\Android" ?>
-      <ComponentGroup Id="AndroidAgentAppComponents" Directory="AndroidAgentAppInstallFolder">
-        <Component Id="AndroidAgentApp.apk" Guid="6CD2D3A9-40D7-4583-BDD1-5B4711431381">
-          <File Id="AndroidAgentApp.apk" Source="$(var.AndroidAgentAppDirectory)\com.xamarin.workbook_app_android-Signed.apk" />
-        </Component>
-      </ComponentGroup>
+    <?define AndroidAgentAppDirectory="..\..\_build\$(var.Configuration)\WorkbookApps\Android" ?>
+    <ComponentGroup Id="AndroidAgentAppComponents" Directory="AndroidAgentAppInstallFolder">
+      <Component Id="AndroidAgentApp.apk" Guid="6CD2D3A9-40D7-4583-BDD1-5B4711431381">
+        <File Id="AndroidAgentApp.apk" Source="$(var.AndroidAgentAppDirectory)\com.xamarin.workbook_app_android-Signed.apk" />
+      </Component>
+    </ComponentGroup>
     <?endif?>
-
     <ComponentGroup Id="WorkbookManifestComponents" Directory="AgentAppInstallFolder">
       <Component Id="workbookapps.json" Guid="47A8314B-0E4A-48BD-AA24-84A18AE06291">
         <File Id="workbookapps.json" Source="..\..\_build\$(var.Configuration)\WorkbookApps\workbookapps.json" />

--- a/Package/Windows/DotNetCoreAgentAppFiles-win-x86.wxs
+++ b/Package/Windows/DotNetCoreAgentAppFiles-win-x86.wxs
@@ -664,6 +664,12 @@
       <Component Id="DNCAgentAppwinx86.System.Memory.dll" Guid="FDA9A09B-F94B-4509-BAB8-919511A724DF">
         <File Id="DNCAgentAppwinx86.System.Memory.dll" Source="$(var.DotNetCoreAssembliesDir)\System.Memory.dll" />
       </Component>
+      <Component Id="DNCAgentAppwinx86.mscordaccore_x86_x86_4.6.26515.07.dll" Guid="A79CC6CE-1A0A-4FCC-9EE9-B40A26274239">
+        <File Id="DNCAgentAppwinx86.mscordaccore_x86_x86_4.6.26515.07.dll" Source="$(var.DotNetCoreAssembliesDir)\mscordaccore_x86_x86_4.6.26515.07.dll" />
+      </Component>
+      <Component Id="DNCAgentAppwinx86.sos_x86_x86_4.6.26515.07.dll" Guid="B4810B78-BFF9-41CD-98FD-38674A4BB261">
+        <File Id="DNCAgentAppwinx86.sos_x86_x86_4.6.26515.07.dll" Source="$(var.DotNetCoreAssembliesDir)\sos_x86_x86_4.6.26515.07.dll" />
+      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/WorkbookApps/Xamarin.Workbooks.Wpf/Xamarin.Workbooks.Wpf.csproj
+++ b/WorkbookApps/Xamarin.Workbooks.Wpf/Xamarin.Workbooks.Wpf.csproj
@@ -60,6 +60,9 @@
     <PackageReference Include="System.ValueTuple">
       <Version>4.4.0</Version>
     </PackageReference>
+    <PackageReference Include="WindowsAPICodePack-Core">
+      <Version>1.1.2</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">


### PR DESCRIPTION
Definitely not for merging at this stage!

-----

I've started experimenting in building a Globals Variable view.

The reason for this is because I've found people want a "debugger autos/locals/watch window" like experience - and it's what they find in the (for example) the RStudio REPL
![image](https://user-images.githubusercontent.com/533662/48978184-8f555280-f09f-11e8-9023-c9e2c241bcc6.png)
(Please excuse the bad retina screen menus - caused by my weird multi-monitor setup!)

-----

To start exploring this idea, I've built quite a hacky way of returning the globals after every evaluation and adding a simple display to the existing page header - but I don't think this is the way this should ultimately be done - a proper solution would:
- be more efficient in its agent-UI comms
- find a better on-screen position for the globals display (and include variable names, and have a scroll bar, and have in-place incremental updating)
- I'm also wondering about adding some pure typescript/javascript code - I'm in awe of the C#/Javascript interop code I've found in this solution, but I don't yet find it very productive compared to Angular or React development.

This current demo code produces an experience like:
![globalswindow](https://user-images.githubusercontent.com/533662/48978132-a0519400-f09e-11e8-8a99-85cb7b2bf1d7.gif)

------

Is this sort of thing something that would be of interest to the main Workbooks product?