### PR TITLE
Client: Show correct error when unable to connect XF workbook to Android

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -1,5 +1,10 @@
 # Version @BUILD_DOCUMENTATION_VERSION@
 
+* Fix wrong error message being displayed when a Xamarin.Forms workbook fails to
+  connect due to emulator issues.
+
+# Version 1.5.0
+
 Please refer to the [detailed release notes][docs-detailed-release-notes] and
 full product documentation for [Workbooks][docs-workbooks] and
 [Inspector][docs-inspector] for complete information.


### PR DESCRIPTION
If connection fails, correct "Unable to start Android emulator" message
gets pushed to the status area.

"Optional Features" configuration was ignoring connection status. It
then tried (and failed) to set up the XF feature, and the error message for this
failure took precedence in the status area.

Have connection init return a boolean value indicating success so that
feature configuration work can be skipped when there is no connection.

The correct error message is now displayed to the user in this case.