### PR TITLE
Mac: Force light mode on Mojave

### DIFF
--- a/Clients/Xamarin.Interactive.Client.Mac/Info.plist
+++ b/Clients/Xamarin.Interactive.Client.Mac/Info.plist
@@ -24,6 +24,8 @@
 	<string>0.1.2.3</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.2</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
We can undo this after we fix bugs with dark mode.