### PR TITLE
Android: Skip optimized view rendering on Pie

### DIFF
--- a/Agents/Xamarin.Interactive.Android/ViewRenderer.cs
+++ b/Agents/Xamarin.Interactive.Android/ViewRenderer.cs
@@ -12,6 +12,7 @@ using System.IO;
 using Java.Interop;
 
 using Android.Graphics;
+using Android.OS;
 using Android.Views;
 using GL = Android.Opengl;
 using Android.Runtime;
@@ -107,12 +108,18 @@ namespace Xamarin.Interactive.Android
 
         public static Bitmap Render (View view, bool skipChildren)
         {
-            var bitmap = RenderUsingCreateSnapshot (view, skipChildren);
+            Bitmap bitmap = null;
 
-            // Canvas drawing and drawing cache can't skip children,
-            // so don't pass the flag down to them.
-            if (bitmap == null)
-                bitmap = RenderUsingCanvasDrawing (view);
+            // createSnapshot signature changed in SDK 28, and requires fixes before we try using it again.
+            // Canvas Drawing also seems not to work for us in SDK 28.
+            if ((int)Build.VERSION.SdkInt < 28) {
+                bitmap = RenderUsingCreateSnapshot (view, skipChildren);
+
+                // Canvas drawing and drawing cache can't skip children,
+                // so don't pass the flag down to them.
+                if (bitmap == null)
+                    bitmap = RenderUsingCanvasDrawing (view);
+            }
 
             if (bitmap == null)
                 bitmap = RenderUsingDrawingCache (view);


### PR DESCRIPTION
Android view rendering has three possible paths. In order of preference,
they are:

1. RenderUsingCreateSnapshot
2. RenderUsingCanvasDrawing
3. RenderUsingDrawingCache

In Pie, the inputs to `createSnapshot` changed, so our JNI invocation no
longer works.

Oreo: https://android.googlesource.com/platform/frameworks/base/+/oreo-release/core/java/android/view/View.java#18385
Pie: https://android.googlesource.com/platform/frameworks/base/+/pie-release/core/java/android/view/View.java#19496

Additionally, the canvas drawing path seems to return an
_empty_ bitmap (instead of a `null` bitmap, which would let us know to
try the final method).

The result is that when using a Pie emulator, Android views render as
empty white shapes:

![workbooks-pie-broken](https://user-images.githubusercontent.com/155076/49466472-0502a200-f7b5-11e8-94b7-649c0e53dbcd.png)

As a workaround until these rendering paths are fixed, force use of
`RenderUsingDrawingCache` when running on emulators with Pie or later.

Notice how parent views are rendered incorrectly (as if the child views are a part of them):

![workbooks-pie](https://user-images.githubusercontent.com/155076/49466303-945b8580-f7b4-11e8-9d06-a311279f2d57.png)

Compare to rendering when using an Oreo emulator instead:

![workbooks-oreo](https://user-images.githubusercontent.com/155076/49466295-8f96d180-f7b4-11e8-80fc-3d98c8050c11.png)
